### PR TITLE
disk space calculation should be on the tmp folder

### DIFF
--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -57,7 +57,7 @@ class Helper(object):
     @classmethod
     def _diskspace(cls):
         """Return the free disk space available (in bytes) in cdm_path."""
-        statvfs = os.statvfs(cls._addon_cdm_path())
+        statvfs = os.statvfs(cls._temp_path())
         return statvfs.f_frsize * statvfs.f_bavail
 
     @classmethod


### PR DESCRIPTION
Some raspberry pi installation have a really small storage space which is not enough when trying to download ~2GB file [when downloading the chromeos image]. To overcome this problem, the tmp folder inside the addon folder, can be mounted to a external disk storage [with a ln softlink]. Therefore the disk space calculation should be based on the tmp folder.