### PR TITLE
Fix python3 crash

### DIFF
--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -610,7 +610,7 @@ class Helper(object):
         if self._cmd_exists('ldd'):
             if not os.access(self._widevine_path(), os.X_OK):
                 self._log('Changing {0} permissions to 744.'.format(self._widevine_path()))
-                os.chmod(self._widevine_path(), 0744)  # this needs to be octal in python 3
+                os.chmod(self._widevine_path(), 0o744)
 
             missing_libs = []
             cmd = ['ldd', self._widevine_path()]


### PR DESCRIPTION
Hello,

as you may know, Kodi 19 will only support python3 and new addons are forced to support python2 and python3.
Currently addons using inputstreamhelper are crashing just for importing inputstreamhelper.

To fix this, this small change is required. This syntax is allowed by both python2 and python3 for octal numbers.

I did not test the Widevine download functionality with python3 but everything else seems to work.