### PR TITLE
Make option to disable module visible in GUI

### DIFF
--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -205,8 +205,12 @@ class Helper:
 
     def _helper_disabled(self):
         """Return if inputstreamhelper has been disabled in settings.xml."""
-        disabled = ADDON.getSettingBool('disabled')
-        if disabled:
+        disabled = ADDON.getSetting('disabled')
+        if not disabled:
+            ADDON.setSetting('disabled', 'false')  # create default entry
+            disabled = 'false'
+
+        if disabled == 'true':
             self._log('inputstreamhelper is disabled in settings.xml.')
             return True
 

--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -205,19 +205,14 @@ class Helper:
 
     def _helper_disabled(self):
         """Return if inputstreamhelper has been disabled in settings.xml."""
-        disabled = ADDON.getSetting('disabled')
-        if not disabled:
-            ADDON.setSetting('disabled', 'false')  # create default entry
-            disabled = 'false'
-
-        if disabled == 'true':
+        disabled = ADDON.getSettingBool('disabled')
+        if disabled:
             self._log('inputstreamhelper is disabled in settings.xml.')
             return True
 
         self._log('inputstreamhelper is enabled. You can disable inputstreamhelper by setting \"disabled\" to \"true\" in settings.xml \
         (Note: only recommended for developers knowing what they\'re doing!)')
         return False
-
     def _inputstream_version(self):
         addon = xbmcaddon.Addon(self.inputstream_addon)
         return addon.getAddonInfo('version')

--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -213,6 +213,7 @@ class Helper:
         self._log('inputstreamhelper is enabled. You can disable inputstreamhelper by setting \"disabled\" to \"true\" in settings.xml \
         (Note: only recommended for developers knowing what they\'re doing!)')
         return False
+
     def _inputstream_version(self):
         addon = xbmcaddon.Addon(self.inputstream_addon)
         return addon.getAddonInfo('version')

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -177,6 +177,3 @@ msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr ""
 
-msgctxt "#30047"
-msgid "Disable"
-msgstr "Deaktivieren"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -177,6 +177,6 @@ msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr ""
 
-msgctxt "#30042"
+msgctxt "#30047"
 msgid "Disable"
 msgstr "Deaktivieren"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -176,3 +176,7 @@ msgstr ""
 msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr ""
+
+msgctxt "#30042"
+msgid "Disable"
+msgstr "Deaktivieren"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -212,3 +212,8 @@ msgstr ""
 msgctxt "#30050"
 msgid "Finishing..."
 msgstr ""
+
+msgctxt "#30053"
+msgid "Disable"
+msgstr ""
+

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -176,3 +176,7 @@ msgstr "Aggiornamento disponibile"
 msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr "E' richiesto Widevine CDM"
+
+msgctxt "#30042"
+msgid "Disable"
+msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -177,6 +177,3 @@ msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr "E' richiesto Widevine CDM"
 
-msgctxt "#30042"
-msgid "Disable"
-msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-   <setting id="disabled" value="" visible="false" />
+   <setting label=30053 id="disabled" type="bool" value="" />
    <setting id="last_update" value="" visible="false" />
 </settings>


### PR DESCRIPTION
As stated in #32 with this change you can enable/disable inputstreamhelper via GUI at 
"kodi settings" > "system" (change from standard to expert there) > "addons" > "manage dependencies" > "Inputstream Helper" > "configure".