### PR TITLE
Changed hwid to one with smaller image file size

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -78,7 +78,7 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 
 CHROMEOS_RECOVERY_URL_LEGACY = 'https://gist.githubusercontent.com/emilsvennesson/5e74181c9a833129ad0bb03ccb41d81f/raw/8d162568277caaa31b54f4773e75a20514856825/recovery.conf'
 
-CHROMEOS_ARM_HWID = 'SPRING'
+CHROMEOS_ARM_HWID = 'SKATE'
 
 CHROMEOS_BLOCK_SIZE = 512
 


### PR DESCRIPTION
My config: Raspbian Stretch Lite, Raspberry Pi 3B+, LXDE/Openbox, Kodi 18.0-1

The Widevine installer was failing to mount and extract the recovery image, so I performed a little experiment. I downloaded the SPRING recovery image myself, and tried to convert it from a binary to an ISO image and mount it, since if that worked, it would have been possible to extract libwidevine.so myself. bchunk failed because the file size was too large, which means that most likely, the installer was failing for the same reason. So, knowing I needed a smaller image, I looked up which other 32-bit ARM Chromebooks there are. It turns out there's an ARM HP Chromebook, hwid "SKATE," whose recovery image is just under 600mb. I tried to convert and mount that, and it worked. The installer still fails before completion because it can't create the widevine-config.json file, which can be fixed by converting Google's recovery.conf file to json and copying it into the right folders manually, but I can confirm that the installer is now able to extract a working libwidevine.so from the image before it fails. This shouldn't negatively affect system configs on which the SPRING recovery image already extracts properly, if anything the download will finish more quickly because of the lower file size.