### PR TITLE
Use versions.txt to get the latest version

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -62,9 +62,9 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
     'Darwin': '17.4'
 }
 
-WIDEVINE_CURRENT_VERSION_URL = 'https://dl.google.com/widevine-cdm/current.txt'
+WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
 
-WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{0}-{1}-{2}.zip'
+WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'
 
 WIDEVINE_LICENSE_FILE = 'LICENSE.txt'
 
@@ -72,7 +72,7 @@ WIDEVINE_MANIFEST_FILE = 'manifest.json'
 
 WIDEVINE_CONFIG_NAME = 'widevine_config.json'
 
-WIDEVINE_UPDATE_INTERVAL_DAYS = 30
+WIDEVINE_UPDATE_INTERVAL_DAYS = 14
 
 WIDEVINE_LEGACY_VERSION = '1.4.8.903'
 
@@ -80,7 +80,7 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 
 CHROMEOS_RECOVERY_URL_LEGACY = 'https://gist.githubusercontent.com/emilsvennesson/5e74181c9a833129ad0bb03ccb41d81f/raw/8d162568277caaa31b54f4773e75a20514856825/recovery.conf'
 
-CHROMEOS_ARM_HWID = 'SPRING'
+CHROMEOS_ARM_HWID = 'SKATE'
 
 CHROMEOS_BLOCK_SIZE = 512
 

--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -406,16 +406,18 @@ class Helper(object):
     def _latest_widevine_version(self, eula=False):
         """Returns the latest available version of Widevine CDM/Chrome OS."""
         if eula:
-            self._url = config.WIDEVINE_CURRENT_VERSION_URL
-            return self._http_request()
+            self._url = config.WIDEVINE_VERSIONS_URL
+            versions = self._http_request()
+            return versions.split()[-1]
 
         ADDON.setSetting('last_update', str(time.mktime(datetime.utcnow().timetuple())))
         if 'x86' in self._arch():
             if self._legacy():
                 return config.WIDEVINE_LEGACY_VERSION
             else:
-                self._url = config.WIDEVINE_CURRENT_VERSION_URL
-                return self._http_request()
+                self._url = config.WIDEVINE_VERSIONS_URL
+                versions = self._http_request()
+                return versions.split()[-1]
         else:
             return [x for x in self._chromeos_config() if config.CHROMEOS_ARM_HWID in x['hwidmatch']][0]['version']
 
@@ -447,7 +449,7 @@ class Helper(object):
             cdm_version = cdm_version.split('.')[-1]
         cdm_os = config.WIDEVINE_OS_MAP[self._os()]
         cdm_arch = config.WIDEVINE_ARCH_MAP_X86[self._arch()]
-        self._url = config.WIDEVINE_DOWNLOAD_URL.format(cdm_version, cdm_os, cdm_arch)
+        self._url = config.WIDEVINE_DOWNLOAD_URL.format(version=cdm_version, os=cdm_os, arch=cdm_arch)
 
         downloaded = self._http_request(download=True)
         if downloaded:
@@ -591,7 +593,7 @@ class Helper(object):
                 eula = f.read().strip().replace('\n', ' ')
         else:  # grab the license from the x86 files
             self._log('Acquiring Widevine EULA from x86 files.')
-            self._url = config.WIDEVINE_DOWNLOAD_URL.format(self._latest_widevine_version(eula=True), 'mac', 'x64')
+            self._url = config.WIDEVINE_DOWNLOAD_URL.format(version=self._latest_widevine_version(eula=True), os='mac', arch='x64')
             downloaded = self._http_request(download=True, message=LANGUAGE(30025))
             if downloaded:
                 with zipfile.ZipFile(self._download_path) as z:


### PR DESCRIPTION
This PR includes:
- Move to using versions.txt instead of current.txt for non-ARM platforms
- Update ARM hwid from SPRING to SKATE (smallest and latest ARM image)
- Decrease the version check from 30 days to 14 days
- Use a better formatted link

This fixes #59 