### PR TITLE
convert Dutch strings.po to UTF-8

### DIFF
--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -23,7 +23,7 @@ msgstr "Deze add-on heeft een decryptie-module van een derde partij nodig [B]Wid
 
 msgctxt "#30003"
 msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr "[B]Widevine CDM[/B] is geïnstalleerd."
+msgstr "[B]Widevine CDM[/B] is geÃ¯nstalleerd."
 
 msgctxt "#30004"
 msgid "Error"


### PR DESCRIPTION
The file was previously encoded in Western ISO
UTF-8 is a requirement for official Kodi repo.