### PR TITLE
Remove legacy support

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -60,9 +60,9 @@ WIDEVINE_SUPPORTED_OS = [
 
 WIDEVINE_MINIMUM_KODI_VERSION = {
     'Android': '18.0',
-    'Windows': '17.4',
-    'Linux': '17.4',
-    'Darwin': '17.4'
+    'Windows': '18.0',
+    'Linux': '18.0',
+    'Darwin': '18.0'
 }
 
 WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
@@ -77,11 +77,7 @@ WIDEVINE_CONFIG_NAME = 'widevine_config.json'
 
 WIDEVINE_UPDATE_INTERVAL_DAYS = 14
 
-WIDEVINE_LEGACY_VERSION = '1.4.8.903'
-
 CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.conf'
-
-CHROMEOS_RECOVERY_URL_LEGACY = 'https://gist.githubusercontent.com/emilsvennesson/5e74181c9a833129ad0bb03ccb41d81f/raw/8d162568277caaa31b54f4773e75a20514856825/recovery.conf'
 
 CHROMEOS_ARM_HWID = 'SKATE'
 

--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -140,11 +140,6 @@ class Helper:
         return version.split(' ')[0]
 
     @classmethod
-    def _legacy(cls):
-        ''' Return whether this is a legacy system '''
-        return LooseVersion('18.0') > LooseVersion(cls._kodi_version())
-
-    @classmethod
     def _arch(cls):
         """Map together and return the system architecture."""
         arch = platform.machine()
@@ -455,9 +450,6 @@ class Helper:
 
         ADDON.setSetting('last_update', str(time.mktime(datetime.utcnow().timetuple())))
         if 'x86' in self._arch():
-            if self._legacy():
-                return config.WIDEVINE_LEGACY_VERSION
-
             self._url = config.WIDEVINE_VERSIONS_URL
             versions = self._http_get().decode()
             return versions.split()[-1]
@@ -467,10 +459,7 @@ class Helper:
     def _chromeos_config(self):
         """Parses the Chrome OS recovery configuration and put it in a dictionary."""
         devices = []
-        if self._legacy():
-            self._url = config.CHROMEOS_RECOVERY_URL_LEGACY
-        else:
-            self._url = config.CHROMEOS_RECOVERY_URL
+        self._url = config.CHROMEOS_RECOVERY_URL
         conf = [x for x in self._http_get().decode().split('\n\n') if 'hwidmatch=' in x]
         for device in conf:
             device_dict = {}
@@ -487,8 +476,6 @@ class Helper:
     def _install_widevine_x86(self):
         """Install Widevine CDM on x86 based architectures."""
         cdm_version = self._latest_widevine_version()
-        if self._legacy():  # google has a different naming scheme on older widevine versions
-            cdm_version = cdm_version.split('.')[-1]
         cdm_os = config.WIDEVINE_OS_MAP[self._os()]
         cdm_arch = config.WIDEVINE_ARCH_MAP_X86[self._arch()]
         self._url = config.WIDEVINE_DOWNLOAD_URL.format(version=cdm_version, os=cdm_os, arch=cdm_arch)


### PR DESCRIPTION
Since the legacy widevine version is no longer supported, and the newer
widevine versions are only supported by Kodi v18, there is no need to
keep legacy support around.

This fixes #66 
This relates to #35 