### PR TITLE
fix unicode error

### DIFF
--- a/lib/inputstreamhelper.py
+++ b/lib/inputstreamhelper.py
@@ -734,7 +734,7 @@ class Helper:
 
     def _extract_widevine_from_img(self):
         """Extracts the Widevine CDM binary from the mounted Chrome OS image."""
-        for root, dirs, files in os.walk(str(self._mnt_path())):  # pylint: disable=unused-variable
+        for root, dirs, files in os.walk(self._mnt_path()):  # pylint: disable=unused-variable
             for filename in files:
                 if filename == 'libwidevinecdm.so':
                     cdm_path = os.path.join(root, filename)

--- a/test/kodi_six/utils.py
+++ b/test/kodi_six/utils.py
@@ -27,7 +27,7 @@ def py2_encode(string, encoding='utf-8'):
 
     In Python 3 the string is not changed.
     """
-    if PY2 and isinstance(string, unicode):  # noqa  # pylint: disable=undefined-variable
+    if PY2 and isinstance(string, unicode):  # noqa pylint: disable=undefined-variable
         string = string.encode(encoding)
     return string
 


### PR DESCRIPTION
This reverts a previous fix https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/48#issuecomment-474529285
We are now using `unicode_literals` and this old fix became counterproductive.