### PR TITLE
directly remove and install Widevine in Kodi CDM dir

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 import sys
 from routing import Plugin
-from inputstreamhelper import ADDON, Helper, remove_widevine
+from inputstreamhelper import ADDON, Helper
 
 plugin = Plugin()
 
@@ -33,7 +33,7 @@ def widevine_install():
 @plugin.route('/widevine/remove')
 def widevine_remove():
     ''' The API interface to remove Widevine CDMs '''
-    remove_widevine()
+    Helper('mpd', drm='widevine').remove_widevine()
 
 
 if __name__ == '__main__':

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,11 +15,12 @@ DRM_SCHEMES = {
     'com.widevine.alpha': 'widevine'
 }
 
-CDM_EXTENSIONS = (
-    '.so',
-    '.dll',
-    '.dylib'
-)
+WIDEVINE_CDM_FILENAME = {
+    'Android': None,
+    'Linux': 'libwidevinecdm.so',
+    'Windows': 'widevinecdm.dll',
+    'Darwin': 'libwidevinecdm.dylib'
+}
 
 ARCH_MAP = {
     'aarch64': 'arm64',

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -21,10 +21,6 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 
-msgctxt "#30003"
-msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr "[B]Widevine CDM[/B] Bibliothek wurde erfolgreich installiert."
-
 msgctxt "#30004"
 msgid "Error"
 msgstr "Fehler"
@@ -177,3 +173,6 @@ msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr ""
 
+msgctxt "#30051"
+msgid "[B]Widevine CDM[/B] successfully installed."
+msgstr "[B]Widevine CDM[/B] Bibliothek wurde erfolgreich installiert."

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -21,10 +21,6 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr "Το πρόσθετο αυτό εξαρτάται από την ιδιοταγή μονάδα αποκρυπτογράφισης [B]Widevine CDM[/B] για αναπαραγωγή."
 
-msgctxt "#30003"
-msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr "Το [B]Widevine CDM[/B] έχει επιτυχώς εγκατασταθεί."
-
 msgctxt "#30004"
 msgid "Error"
 msgstr "Σφάλμα"
@@ -176,3 +172,7 @@ msgstr "Η ενημέρωση ολοκληρώθηκε"
 msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr "Απαιτείται το Widevine CDM"
+
+msgctxt "#30051"
+msgid "[B]Widevine CDM[/B] successfully installed."
+msgstr "Το [B]Widevine CDM[/B] έχει επιτυχώς εγκατασταθεί."

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -21,10 +21,6 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr ""
 
-msgctxt "#30003"
-msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr ""
-
 msgctxt "#30004"
 msgid "Error"
 msgstr ""
@@ -214,11 +210,15 @@ msgid "Finishing..."
 msgstr ""
 
 msgctxt "#30051"
-msgid "Widevine CDM was successfully removed."
+msgid "[B]Widevine CDM[/B] successfully installed."
 msgstr ""
 
 msgctxt "#30052"
-msgid "Widevine CDM was not found."
+msgid "[B]Widevine CDM[/B] successfully removed."
+msgstr ""
+
+msgctxt "#30053"
+msgid "[B]Widevine CDM[/B] not found."
 msgstr ""
 
 msgctxt "#30900"
@@ -234,9 +234,9 @@ msgid "When disabled, DRM updates are suspended and DRM playback may fail!"
 msgstr ""
 
 msgctxt "#30905"
-msgid "Install the Widevine CDM library..."
+msgid "Install Widevine CDM library..."
 msgstr ""
 
 msgctxt "#30907"
-msgid "Remove the Widevine CDM library..."
+msgid "Remove Widevine CDM library..."
 msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -21,10 +21,6 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr "Per la riproduzzione, questo addon fa affidamento al modulo di decriptazione proprietario [B]Widevine CDM[/B]"
 
-msgctxt "#30003"
-msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr "[B]Widevine CDM[/B] installato con successo."
-
 msgctxt "#30004"
 msgid "Error"
 msgstr "Errore"
@@ -177,3 +173,6 @@ msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr "E' richiesto Widevine CDM"
 
+msgctxt "#30051"
+msgid "[B]Widevine CDM[/B] successfully installed."
+msgstr "[B]Widevine CDM[/B] installato con successo."

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -21,10 +21,6 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr "Deze add-on heeft een decryptie-module van een derde partij nodig [B]Widevine CDM[/B] om af te spelen."
 
-msgctxt "#30003"
-msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr "[B]Widevine CDM[/B] is geïnstalleerd."
-
 msgctxt "#30004"
 msgid "Error"
 msgstr "Fout"
@@ -176,3 +172,7 @@ msgstr "Update beschikbaar"
 msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr "Widevine CDM is nodig"
+
+msgctxt "#30051"
+msgid "[B]Widevine CDM[/B] successfully installed."
+msgstr "[B]Widevine CDM[/B] met succes geïnstalleerd."

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -21,10 +21,6 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr "Для воспроизведения, этому дополнению требуется проприетарный модуль дешифрования [B]Widevine CDM[/B]."
 
-msgctxt "#30003"
-msgid "[B]Widevine CDM[/B] was successfully installed."
-msgstr "[B]Widevine CDM[/B] был успешно установлен."
-
 msgctxt "#30004"
 msgid "Error"
 msgstr "Ошибка"
@@ -176,3 +172,7 @@ msgstr "Обновление доступно"
 msgctxt "#30041"
 msgid "Widevine CDM is required"
 msgstr "Требуется Widevine CDM"
+
+msgctxt "#30051"
+msgid "[B]Widevine CDM[/B] successfully installed."
+msgstr "[B]Widevine CDM[/B] был успешно установлен."

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -33,7 +33,7 @@ except OSError as e:
     }
 
 
-def executebuiltin(string):  # pylint: disable=unused-argument
+def executebuiltin(function, wait=False):  # pylint: disable=unused-argument
     ''' A stub implementation of the xbmc executebuiltin() function '''
     return
 


### PR DESCRIPTION
This pull request includes:
- fix for removing Widevine on Windows
- move `remove_widevine` to Helper class
- always use Kodi CDM dir to install Widevine CDM to, phase out use of inputstreamhelper addon data CDM dir
- determine widevine path based on static filename (just like InputStream Adaptive does)
- wait until InputStream Adaptive installation is complete (xmbc.executebuiltin wait parameter)
- use notification dialogs when installing or removing Widevine CDM
