### PR TITLE
Ensure only a single plugin icon

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -6,6 +6,13 @@ import sys
 from routing import Plugin
 from inputstreamhelper import ADDON, Helper
 
+# NOTE: Work around an issue in script.module.routing
+#       https://github.com/tamland/kodi-plugin-routing/pull/16
+if len(sys.argv) < 1:
+    sys.argv.append('addon.py')
+if len(sys.argv) < 2:
+    sys.argv.append('-1')
+
 plugin = Plugin()
 
 

--- a/addon.xml
+++ b/addon.xml
@@ -2,16 +2,14 @@
 <addon id="script.module.inputstreamhelper" version="0.3.5" name="InputStream Helper" provider-name="emilsvennesson">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
-        <import addon="script.module.inputstreamhelper" version="0.3.5" optional="true"/>
+        <import addon="script.module.inputstreamhelper" optional="true"/>
         <import addon="script.module.kodi-six" version="0.0.4"/>
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
         <import addon="script.module.routing" version="0.2.0"/>
     </requires>
     <extension point="xbmc.python.module" library="lib"/>
     <!-- This is needed for running from RunPlugin() -->
-    <extension point="xbmc.python.pluginsource" library="addon.py">
-        <provides>executable</provides>
-    </extension>
+    <extension point="xbmc.python.pluginsource" library="addon.py"/>
     <!-- This is needed for running from Information pane -->
     <extension point="xbmc.python.script" library="addon.py"/>
     <extension point="xbmc.addon.metadata">

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -230,7 +230,7 @@ msgid "Disable InputStream Helper"
 msgstr ""
 
 msgctxt "#30904"
-msgid "When disabled, DRM playback may fail!"
+msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -230,7 +230,7 @@ msgid "Disable InputStream Helper"
 msgstr ""
 
 msgctxt "#30904"
-msgid "When disabled, DRM playback may fail!"
+msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -230,7 +230,7 @@ msgid "Disable InputStream Helper"
 msgstr ""
 
 msgctxt "#30904"
-msgid "When disabled, DRM playback may fail!"
+msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -230,8 +230,8 @@ msgid "Disable InputStream Helper"
 msgstr "InputStream Helper afzetten"
 
 msgctxt "#30904"
-msgid "When disabled, DRM playback may fail!"
-msgstr "Indien niet actief kan het afspelen van DRM content falen!"
+msgid "[I]When disabled, DRM playback may fail![/I]"
+msgstr "[I]Indien niet actief kan het afspelen van DRM content falen![/I]"
 
 msgctxt "#30905"
 msgid "Install Widevine CDM library..."

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -230,7 +230,7 @@ msgid "Disable InputStream Helper"
 msgstr ""
 
 msgctxt "#30904"
-msgid "When disabled, DRM playback may fail!"
+msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"


### PR DESCRIPTION
This PR includes:
- A fix for the double plugin icons
- A workaround for a script.module.routing bug
- Visual fix for the settings

This fixes #108 