### PR TITLE
Use "(Re)install Widevine CDM" for settings

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -234,7 +234,7 @@ msgid "When disabled, DRM playback may fail!"
 msgstr ""
 
 msgctxt "#30905"
-msgid "Install Widevine CDM library..."
+msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
 msgctxt "#30907"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -234,7 +234,7 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"
-msgid "Install Widevine CDM library..."
+msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
 msgctxt "#30907"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -234,7 +234,7 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"
-msgid "Install Widevine CDM library..."
+msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
 msgctxt "#30907"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -234,7 +234,7 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"
-msgid "Install Widevine CDM library..."
+msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
 msgctxt "#30907"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -234,8 +234,8 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]Indien niet actief kan het afspelen van DRM content falen![/I]"
 
 msgctxt "#30905"
-msgid "Install Widevine CDM library..."
-msgstr "Widevine CDM installeren..."
+msgid "(Re)install Widevine CDM library..."
+msgstr "Widevine CDM (her)installeren..."
 
 msgctxt "#30907"
 msgid "Remove Widevine CDM library..."

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -234,7 +234,7 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"
-msgid "Install Widevine CDM library..."
+msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
 msgctxt "#30907"


### PR DESCRIPTION
Since this option will also reinstall Widevine CDM if it was already
installed, we want to add this subtlety.

This relates to #101 