### PR TITLE
simplify entry point to speed up loading time

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1,50 +1,8 @@
 # -*- coding: utf-8 -*-
-''' This is the actual InputStream Helper plugin entry point '''
+''' This is the actual InputStream Helper API script entry point '''
 
 from __future__ import absolute_import, division, unicode_literals
 import sys
-from inputstreamhelper import ADDON, Helper, log
+from api import run
 
-
-def run(params):
-    ''' Route to API method '''
-    if 2 <= len(params) <= 4:
-        if params[1] == 'widevine_install':
-            widevine_install()
-        elif params[1] == 'widevine_remove':
-            widevine_remove()
-        elif params[1] == 'check_inputstream':
-            if len(params) == 3:
-                check_inputstream(params[2])
-            elif len(params) == 4:
-                check_inputstream(params[2], drm=params[3])
-        elif params[1] == 'about':
-            about_dialog()
-    elif len(params) > 4:
-        log('invalid API call, too many parameters')
-    else:
-        ADDON.openSettings()
-
-
-def check_inputstream(protocol, drm=None):
-    ''' The API interface to check inputstream '''
-    Helper(protocol, drm=drm).check_inputstream()
-
-
-def widevine_install():
-    ''' The API interface to install Widevine CDM '''
-    Helper('mpd', drm='widevine').install_widevine()
-
-
-def widevine_remove():
-    ''' The API interface to remove Widevine CDMs '''
-    Helper('mpd', drm='widevine').remove_widevine()
-
-
-def about_dialog():
-    ''' The API interface to show an about Dialog '''
-    Helper('mpd', drm='widevine').about_dialog()
-
-
-if __name__ == '__main__':
-    run(sys.argv)
+run(sys.argv)

--- a/lib/api.py
+++ b/lib/api.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+''' This is the actual InputStream Helper API script '''
+
+from __future__ import absolute_import, division, unicode_literals
+from inputstreamhelper import ADDON, Helper, log
+
+
+def run(params):
+    ''' Route to API method '''
+    if 2 <= len(params) <= 4:
+        if params[1] == 'widevine_install':
+            widevine_install()
+        elif params[1] == 'widevine_remove':
+            widevine_remove()
+        elif params[1] == 'check_inputstream':
+            if len(params) == 3:
+                check_inputstream(params[2])
+            elif len(params) == 4:
+                check_inputstream(params[2], drm=params[3])
+        elif params[1] == 'about':
+            about_dialog()
+    elif len(params) > 4:
+        log('invalid API call, too many parameters')
+    else:
+        ADDON.openSettings()
+
+
+def check_inputstream(protocol, drm=None):
+    ''' The API interface to check inputstream '''
+    Helper(protocol, drm=drm).check_inputstream()
+
+
+def widevine_install():
+    ''' The API interface to install Widevine CDM '''
+    Helper('mpd', drm='widevine').install_widevine()
+
+
+def widevine_remove():
+    ''' The API interface to remove Widevine CDMs '''
+    Helper('mpd', drm='widevine').remove_widevine()
+
+
+def about_dialog():
+    ''' The API interface to show an about Dialog '''
+    Helper('mpd', drm='widevine').about_dialog()


### PR DESCRIPTION
The python files refered in addon.xml won't get compiled to bytecode, so we have to keep addon.py short and simple to speed up loading times.