### PR TITLE
0.4.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+## v0.4.2 (2019-09-03)
+- Move release history to readme file (@mediaminister)
+- Clean up coverage/codecov config (@dagwieers)
+- Add InputStream Helper Information to settings page (@horstle, @dagwieers)
+- Make sure addon.xml meets all requirements (@mediaminister)
+- Simplify add-on entry point to speed up loading time (@mediaminister)
+- Unicode fix for os.walk (@mediaminister)
+- Revert "Fix ARM processing in unittest locally" (@mediaminister)
+- Fix unresponsive Kodi when opening add-on information pane (@dagwieers, @mediaminister)
+- Add-on structure improvements (@dagwieers)
+
 ## v0.4.1 (2019-09-01)
 - Follow kodi-addon-checker recommended code changes (@mediaminister)
 - Implement api using runscript (@mediaminister)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.1" provider-name="emilsvennesson, dagwieers">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.2" provider-name="emilsvennesson, dagwieers">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.kodi-six" version="0.0.4"/>
@@ -14,22 +14,16 @@
     <description lang="el_GR">Μία απλή μονάδα για το Kodi η οποία διευκολύνει την ζωή των προγραμματιστών οι οποίοι εξαρτώνται από τα πρόσθετσ InputStream και αναπαραγωγή τύπου DRM.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
-      v0.4.1 (2019-09-01)
-        - Use local url variable
-        - Directly use Kodi CDM directory
-        - Implement settings menu and API
-        - Add integration tests
-        - Add a progress dialog for extraction on ARM
-        - Fix crash when using platform.system()
-        - Fix a python error
-        - Remove legacy Widevine CDM support
-        - Replace requests/urllib3 with urllib/urllib2
-        - Various unicode fixes
-        - Add proxy support
-        - Add setting to disable inputstreamhelper
-        - Check Widevine support before all checks
-        - Support 64-bit kernel with 32-bit userspace
-        - Dutch, German, Greek, Italian, Russian and Swedish translations
+      v0.4.2 (2019-09-03)
+        - Move release history to readme file
+        - Clean up coverage/codecov config
+        - Add InputStream Helper Information to settings page
+        - Make sure addon.xml meets all requirements
+        - Simplify add-on entry point to speed up loading time
+        - Unicode fix for os.walk
+        - Revert "Fix ARM processing in unittest locally"
+        - Fix unresponsive Kodi when opening add-on information pane
+        - Add-on structure improvements        
     </news>
     <platform>all</platform>
     <license>MIT</license>


### PR DESCRIPTION
Because 0.4.1 with https://github.com/emilsvennesson/script.module.inputstreamhelper/commit/0993eef6f5660d871559428cf89560bc9bff8f29 broke libwidevinecdm.so extraction from Chrome OS, I reverted this commit. Now we need to release a 0.4.2 version so InputStream Helper is functional again for people using platforms like Rpi and Odroid.
@basrieter @dagwieers @emilsvennesson Please test and approve