### PR TITLE
Rename 'About' into 'IS Info'

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -1014,33 +1014,30 @@ class Helper:
 
         return dict(http=proxy_address, https=proxy_address)
 
-    def about_dialog(self):
-        """ Show an About box with useful info e.g. for bug reports"""
-        ishelper = [ADDON.getAddonInfo('version'), '(disabled)' if not ADDON.getSetting('disabled') == 'false' else '']
-        istream = [self._inputstream_version(), '(disabled)' if not self._inputstream_enabled() else '']
-        kodi_version = self._kodi_version()
-        wv_version = self._get_lib_version(self._widevine_path())
+    def info_dialog(self):
+        """ Show an Info box with useful info e.g. for bug reports"""
+        disabled_str = ' ({disabled}'.format(disabled=localize(30054))
+
+        kodi_info = [localize(30801, version=self._kodi_version()),
+                     localize(30802, platform=system_os(), arch=self._arch())]
+
+        ishelper_state = disabled_str if not ADDON.getSetting('disabled') == 'false' else ''
+        istream_state = disabled_str if not self._inputstream_enabled() else ''
+        is_info = [localize(30811, version=ADDON.getAddonInfo('version'), state=ishelper_state),
+                   localize(30812, version=self._inputstream_version(), state=istream_state)]
+
         wv_updated = datetime.fromtimestamp(float(ADDON.getSetting('last_update'))).strftime("%Y-%m-%d %H:%M") if ADDON.getSetting('last_update') else 'Never'
-        kodi_platform = system_os()
-        arch = self._arch()
-        cdm_dir = self._ia_cdm_path()
-        issue_url = config.ISSUE_URL
-
-        kodi_info = [localize(30921, version=kodi_version),
-                     localize(30922, kodi_platform=kodi_platform, arch=arch)]
-        is_info = [localize(30931, version=ishelper[0], enabled=ishelper[1]),
-                   localize(30932, version=istream[0], enabled=istream[1])]
-        wv_info = [localize(30941, version=wv_version, updated=wv_updated),
-                   localize(30942, cdm_dir=cdm_dir)]
+        wv_info = [localize(30821, version=self._get_lib_version(self._widevine_path()), date=wv_updated),
+                   localize(30822, path=self._ia_cdm_path())]
         if platform == 'arm':
-            wv_info.append(localize(30943, version=ADDON.getSetting('chromeos_version')))
+            wv_info.append(localize(30823, version=ADDON.getSetting('chromeos_version')))
 
-        text = (localize(30920) + "\n - "
+        text = (localize(30800) + "\n - "
                 + "\n - ".join(kodi_info) + "\n\n"
-                + localize(30930) + "\n - "
+                + localize(30810) + "\n - "
                 + "\n - ".join(is_info) + "\n\n"
-                + localize(30940) + "\n - "
+                + localize(30820) + "\n - "
                 + "\n - ".join(wv_info) + "\n\n"
-                + localize(30950, issue_url=issue_url))
+                + localize(30830, url=config.ISSUE_URL))
 
-        xbmcgui.Dialog().textviewer(localize(30909), text)
+        xbmcgui.Dialog().textviewer(localize(30901), text)

--- a/lib/inputstreamhelper/api.py
+++ b/lib/inputstreamhelper/api.py
@@ -17,8 +17,8 @@ def run(params):
                 check_inputstream(params[2])
             elif len(params) == 4:
                 check_inputstream(params[2], drm=params[3])
-        elif params[1] == 'about':
-            about_dialog()
+        elif params[1] == 'info':
+            info_dialog()
     elif len(params) > 4:
         log('invalid API call, too many parameters')
     else:
@@ -40,6 +40,6 @@ def widevine_remove():
     Helper('mpd', drm='widevine').remove_widevine()
 
 
-def about_dialog():
-    ''' The API interface to show an about Dialog '''
-    Helper('mpd', drm='widevine').about_dialog()
+def info_dialog():
+    ''' The API interface to show an info Dialog '''
+    Helper('mpd', drm='widevine').info_dialog()

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -221,9 +221,65 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr "[B]Widevine CDM[/B] wurde nicht gefunden."
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr ""
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr ""
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr ""
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
 msgstr "Fehlerbehebung"
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
+msgstr ""
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -221,9 +221,65 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr "Το [B]Widevine CDM[/B] δεν βρέθηκε"
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr ""
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr ""
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr ""
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
 msgstr "Αντιμετώπιση προβλημάτων"
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
+msgstr ""
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -221,8 +221,64 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr ""
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr ""
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr ""
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr ""
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
+msgstr ""
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
 msgstr ""
 
 msgctxt "#30903"
@@ -241,50 +297,3 @@ msgctxt "#30907"
 msgid "Remove Widevine CDM library..."
 msgstr ""
 
-msgctxt "#30909"
-msgid "About"
-msgstr ""
-
-msgctxt "#30920"
-msgid "[B]Kodi information[/B]"
-msgstr ""
-
-msgctxt "#30921"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr ""
-
-msgctxt "#30922"
-msgid "Kodi platform/architecture: [B]{kodi_platform}/{arch}[/B]"
-msgstr ""
-
-msgctxt "#30930"
-msgid "[B]InputStream information[/B]"
-msgstr ""
-
-msgctxt "#30931"
-msgid "InputStream Helper version: [B]{version}[/B] {enabled}"
-msgstr ""
-
-msgctxt "#30932"
-msgid "InputStream Adaptive version: [B]{version}[/B] {enabled}"
-msgstr ""
-
-msgctxt "#30940"
-msgid "[B]Widevine information[/B]"
-msgstr ""
-
-msgctxt "#30941"
-msgid "Widevine version: [B]{version}[/B] (last update on [B]{updated}[/B])"
-msgstr ""
-
-msgctxt "#30942"
-msgid "Widevine CDM path: [B]{cdm_dir}[/B]"
-msgstr ""
-
-msgctxt "#30943"
-msgid "ChromeOS version: [B]{version}[/B]"
-msgstr ""
-
-msgctxt "#30950"
-msgid "Please report issues to: \n - [B]{issue_url}[/B]"
-msgstr ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -221,8 +221,64 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr "[B]Widevine CDM[/B] non e' stato trovato"
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr ""
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr ""
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr ""
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
+msgstr ""
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
 msgstr ""
 
 msgctxt "#30903"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -222,9 +222,65 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr "[B]Widevine CDM[/B] is niet gevonden."
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr "uitgeschakeld"
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr "[B]Kodi informatie[/B]"
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr "Kodi versie: [B]{version}[/B]"
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr "Kodi platform/architectuur: [B]{platform}[/B]/[B]{arch}[/B]"
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr "[B]InputStream informatie[/B]"
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr "InputStream Helper versie: [B]{version}[/B] {state}"
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr "InputStream Adaptive versie: [B]{version}[/B] {state}"
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr "[B]Widevine informatie[/B]"
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr "Widevine versie: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr "Widevine CDM pad: [B]{path}[/B]"
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr "ChromeOS versie: [B]{version}[/B]"
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr "Graag problemen melden op:\n - [B]{url}[/B]"
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
 msgstr "Foutopsporing"
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
+msgstr "InputStream Helper informatie"
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -221,9 +221,65 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr "[B]Widevine CDM[/B] не найден."
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr ""
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr ""
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr ""
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
 msgstr "Исправление проблем"
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
+msgstr ""
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -221,9 +221,65 @@ msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
 msgstr "[B]Widevine CDM[/B] hittades inte."
 
+msgctxt "#30054"
+msgid "disabled"
+msgstr ""
+
+
+### INFORMATION DIALOG
+msgctxt "#30800"
+msgid "[B]Kodi information[/B]"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Kodi version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgstr ""
+
+msgctxt "#30810"
+msgid "[B]InputStream information[/B]"
+msgstr ""
+
+msgctxt "#30811"
+msgid "InputStream Helper version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30812"
+msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgstr ""
+
+msgctxt "#30820"
+msgid "[B]Widevine information[/B]"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30823"
+msgid "ChromeOS version: [B]{version}[/B]"
+msgstr ""
+
+msgctxt "#30830"
+msgid "Please report issues to:\n - [B]{url}[/B]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30900"
 msgid "Troubleshooting"
 msgstr "Felsökning"
+
+msgctxt "#30901"
+msgid "InputStream Helper information"
+msgstr ""
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,10 +4,10 @@
     <setting id="version" value="" visible="false"/>
     <setting id="chromeos_version" value="" visible="false"/>
     <category label="30900"> <!-- Troubleshooting -->
+        <setting label="30901" type="action" id="info" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting label="30903" help="30904" type="bool" id="disabled" value="false"/>
         <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
         <setting label="30905" help="30906" type="action" id="install_widevine" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="eq(-2,false)" visible="!system.platform.android"/>
         <setting label="30907" help="30908" type="action" id="remove_widevine" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="eq(-3,false)" visible="!system.platform.android"/>
-        <setting label="30909" type="action" id="about" action="RunScript(script.module.inputstreamhelper, about)"/>
     </category>
 </settings>

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,7 +28,7 @@ class TestApi(unittest.TestCase):
 
     @staticmethod
     def test_about():
-        default.run(['default.py', 'about'])
+        default.run(['default.py', 'info'])
 
     @staticmethod
     def test_check_inputstream():

--- a/test/xbmcextra.py
+++ b/test/xbmcextra.py
@@ -10,22 +10,15 @@ def kodi_to_ansi(string):
     ''' Convert Kodi format tags to ANSI codes '''
     if string is None:
         return None
-    string = string.replace('[B]', '[1m')
-    string = string.replace('[/B]', '[0m')
-    string = string.replace('[I]', '[3m')
-    string = string.replace('[/I]', '[0m')
-    string = string.replace('[COLOR gray]', '[30;1m')
-    string = string.replace('[COLOR red]', '[31m')
-    string = string.replace('[COLOR green]', '[32m')
-    string = string.replace('[COLOR yellow]', '[33m')
-    string = string.replace('[COLOR blue]', '[34m')
-    string = string.replace('[COLOR purple]', '[35m')
-    string = string.replace('[/COLOR]', '[0m')
+    string = string.replace('[B]', '\033[1m')
+    string = string.replace('[/B]', '\033[21m')
+    string = string.replace('[I]', '\033[3m')
+    string = string.replace('[/I]', '\033[23m')
+    string = string.replace('[COLOR gray]', '\033[30;1m')
+    string = string.replace('[COLOR red]', '\033[31m')
+    string = string.replace('[COLOR green]', '\033[32m')
+    string = string.replace('[COLOR yellow]', '\033[33m')
+    string = string.replace('[COLOR blue]', '\033[34m')
+    string = string.replace('[COLOR purple]', '\033[35m')
+    string = string.replace('[/COLOR]', '\033[39;0m')
     return string
-
-
-def uri_to_path(uri):
-    ''' Shorten a plugin URI to just the path '''
-    if uri is None:
-        return None
-    return ' [33m→ [34m%s[0m' % uri.replace('plugin://plugin.video.vrt.nu', '')

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -20,21 +20,21 @@ class Dialog:
         ''' A working implementation for the xbmcgui Dialog class notification() method '''
         heading = kodi_to_ansi(heading)
         message = kodi_to_ansi(message)
-        print('[37;100mNOTIFICATION:[35;0m [%s] [35;0m%s[0m' % (heading, message))
+        print('\033[37;100mNOTIFICATION:\033[35;0m [%s] \033[35;0m%s\033[39;0m' % (heading, message))
 
     @staticmethod
     def ok(heading, line1, line2=None, line3=None):
         ''' A stub implementation for the xbmcgui Dialog class ok() method '''
         heading = kodi_to_ansi(heading)
         line1 = kodi_to_ansi(line1)
-        print('[37;100mOK:[35;0m [%s] [35;0m%s[0m' % (heading, line1))
+        print('\033[37;100mOK:\033[35;0m [%s] \033[35;0m%s\033[39;0m' % (heading, line1))
 
     @staticmethod
     def yesno(heading, line1, line2=None, line3=None, nolabel=None, yeslabel=None, autoclose=0):
         ''' A stub implementation for the xbmcgui Dialog class yesno() method '''
         heading = kodi_to_ansi(heading)
         line1 = kodi_to_ansi(line1)
-        print('[37;100mYESNO:[35;0m [%s] [35;0m%s[0m' % (heading, line1))
+        print('\033[37;100mYESNO:\033[35;0m [%s] \033[35;0m%s\033[39;0m' % (heading, line1))
         return True
 
     @staticmethod
@@ -42,7 +42,7 @@ class Dialog:
         ''' A stub implementation for the xbmcgui Dialog class textviewer() method '''
         heading = kodi_to_ansi(heading)
         text = kodi_to_ansi(text)
-        print('[37;100mTEXTVIEWER:[35;0m [%s] [35;0m%s[0m' % (heading, text))
+        print('\033[37;100mTEXTVIEWER:\033[35;0m [%s]\n\033[35;0m%s\033[39;0m' % (heading, text))
 
 
 class DialogProgress:
@@ -62,7 +62,7 @@ class DialogProgress:
         ''' A stub implementation for the xbmcgui DialogProgress class create() method '''
         heading = kodi_to_ansi(heading)
         line1 = kodi_to_ansi(line1)
-        print('[37;100mPROGRESS:[35;0m [%s] [35;0m%s[0m' % (heading, line1))
+        print('\033[37;100mPROGRESS:\033[35;0m [%s] \033[35;0m%s\033[39;0m' % (heading, line1))
 
     @staticmethod
     def iscanceled():
@@ -77,9 +77,9 @@ class DialogProgress:
         line2 = kodi_to_ansi(line2)
         line3 = kodi_to_ansi(line3)
         if line1 or line2 or line3:
-            print('[37;100mPROGRESS:[35;0m [%d%%] [35;0m%s[0m' % (percentage, line1 or line2 or line3))
+            print('\033[37;100mPROGRESS:\033[35;0m [%d%%] \033[35;0m%s\033[39;0m' % (percentage, line1 or line2 or line3))
         else:
-            print('[1G[37;100mPROGRESS:[35;0m [%d%%]' % (percentage), end='')
+            print('\033[1G\033[37;100mPROGRESS:\033[35;0m [%d%%]\033[39;0m' % (percentage), end='')
 
 
 class DialogBusy:


### PR DESCRIPTION
The reason to rename the 'About' dialog to 'InputStream Helper
information' is that it is clearer to the user where the information is
coming from exactly.

As we expect developers to use this from their own add-on for
troubleshooting purposes, it is important to make clear what it is about
(pun intended).

This PR includes:
- Renaming About dialog in Info dialog
- Dutch translations
- Localize '(disabled)' string
- Restructure translation strings (30800: information, 30900: settings)
- Prepare translation to other languages
- Small visual improvements