### PR TITLE
Implement translation tests

### DIFF
--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import os
 import json
-import polib
 
 
 LOGDEBUG = 'Debug'
@@ -18,8 +17,6 @@ LOGNOTICE = 'Notice'
 INFO_LABELS = {
     'System.BuildVersion': '18.2',
 }
-
-PO = polib.pofile('resources/language/resource.language.en_gb/strings.po')
 
 # Use the global_settings file
 try:

--- a/test/xbmcaddon.py
+++ b/test/xbmcaddon.py
@@ -8,8 +8,7 @@ import sys
 import json
 import xml.etree.ElementTree as ET
 import polib
-
-PO = polib.pofile('resources/language/resource.language.en_gb/strings.po')
+from xbmc import GLOBAL_SETTINGS
 
 # Use the addon_settings file
 try:
@@ -54,6 +53,7 @@ def __read_addon_xml(path):
 
 ADDON_INFO = __read_addon_xml('addon.xml')
 ADDON_ID = list(ADDON_INFO)[0]
+PO = polib.pofile('resources/language/{language}/strings.po'.format(language=GLOBAL_SETTINGS.get('locale.language')))
 
 
 class Addon:

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -3,10 +3,10 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ''' This file implements the Kodi xbmcgui module, either using stubs or alternative functionality '''
 
+# pylint: disable=unused-argument,too-many-arguments
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 from xbmcextra import kodi_to_ansi
-
-# pylint: disable=unused-argument,too-many-arguments
 
 
 class Dialog:


### PR DESCRIPTION
This makes it possible to change the locale.language in the global
settings and get localized translations in testing output.