### PR TITLE
consciously use unicode

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,6 @@
 <addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.2" provider-name="emilsvennesson, dagwieers">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
-    <import addon="script.module.kodi-six" version="0.0.4"/>
     <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
   </requires>
   <!-- This is needed to get an addon icon -->

--- a/default.py
+++ b/default.py
@@ -4,7 +4,16 @@
 from __future__ import absolute_import, division, unicode_literals
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'lib'))  # noqa: E402
-from inputstreamhelper.api import run
+import xbmc
+import xbmcaddon
+
+
+def to_unicode(text, encoding='utf-8'):
+    ''' Force text to unicode '''
+    return text.decode(encoding) if isinstance(text, bytes) else text
+
+
+sys.path.append(os.path.join(to_unicode(xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('path'))), 'lib'))
+from inputstreamhelper.api import run  # noqa: E402
 
 run(sys.argv)

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -22,13 +22,16 @@ except ImportError:  # Python 2
 
 from inputstreamhelper import config
 
-from kodi_six import xbmc, xbmcaddon, xbmcgui, xbmcvfs
+import xbmc
+import xbmcaddon
+import xbmcgui
+import xbmcvfs
+from .unicodehelper import to_unicode, from_unicode
 
 ADDON = xbmcaddon.Addon('script.module.inputstreamhelper')
-ADDON_PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
-ADDON_ID = ADDON.getAddonInfo('id')
-ADDON_VERSION = ADDON.getAddonInfo('version')
-
+ADDON_PROFILE = to_unicode(xbmc.translatePath(ADDON.getAddonInfo('profile')))
+ADDON_ID = to_unicode(ADDON.getAddonInfo('id'))
+ADDON_VERSION = to_unicode(ADDON.getAddonInfo('version'))
 
 # NOTE: Work around issue caused by platform still using os.popen()
 #       This helps to survive 'IOError: [Errno 10] No child processes'
@@ -49,7 +52,7 @@ class SafeDict(dict):
 
 def log(msg, **kwargs):
     ''' InputStream Helper log method '''
-    xbmc.log(msg='[{addon}-{version}]: {msg}'.format(addon=ADDON_ID, version=ADDON_VERSION, msg=msg.format(**kwargs)), level=xbmc.LOGDEBUG)
+    xbmc.log(msg=from_unicode('[{addon}-{version}]: {msg}'.format(addon=ADDON_ID, version=ADDON_VERSION, msg=msg.format(**kwargs))), level=xbmc.LOGDEBUG)
 
 
 def localize(string_id, **kwargs):
@@ -152,7 +155,7 @@ class Helper:
     def _ia_cdm_path(cls):
         ''' Return the specified CDM path for inputstream.adaptive, usually ~/.kodi/cdm '''
         addon = xbmcaddon.Addon('inputstream.adaptive')
-        cdm_path = xbmc.translatePath(addon.getSetting('DECRYPTERPATH'))
+        cdm_path = to_unicode(xbmc.translatePath(addon.getSetting('DECRYPTERPATH')))
         if not xbmcvfs.exists(cdm_path):
             xbmcvfs.mkdir(cdm_path)
 
@@ -254,7 +257,7 @@ class Helper:
     def _inputstream_version(self):
         ''' Return the requested inputstream version '''
         addon = xbmcaddon.Addon(self.inputstream_addon)
-        return addon.getAddonInfo('version')
+        return to_unicode(addon.getAddonInfo('version'))
 
     @staticmethod
     def _get_lib_version(path):
@@ -357,7 +360,7 @@ class Helper:
             return True
 
         if self._widevine_path():
-            log('Found Widevine binary at {path}', path=self._widevine_path().encode('utf-8'))
+            log('Found Widevine binary at {path}', path=self._widevine_path())
             return True
 
         log('Widevine is not installed.')
@@ -731,13 +734,12 @@ class Helper:
         settings_version = ADDON.getSetting('version')
         if settings_version == '':
             settings_version = '0.3.4'  # settings_version didn't exist in version 0.3.4 and older
-        addon_version = ADDON.getAddonInfo('version')
 
         # Compare versions
-        if LooseVersion(addon_version) > LooseVersion(settings_version):
+        if LooseVersion(ADDON_VERSION) > LooseVersion(settings_version):
             # New version found, save addon_version to settings
-            ADDON.setSetting('version', addon_version)
-            log('inputstreamhelper version {version} is running for the first time', version=addon_version)
+            ADDON.setSetting('version', ADDON_VERSION)
+            log('inputstreamhelper version {version} is running for the first time', version=ADDON_VERSION)
             return True
         return False
 
@@ -1023,7 +1025,7 @@ class Helper:
 
         ishelper_state = disabled_str if not ADDON.getSetting('disabled') == 'false' else ''
         istream_state = disabled_str if not self._inputstream_enabled() else ''
-        is_info = [localize(30811, version=ADDON.getAddonInfo('version'), state=ishelper_state),
+        is_info = [localize(30811, version=ADDON_VERSION, state=ishelper_state),
                    localize(30812, version=self._inputstream_version(), state=istream_state)]
 
         wv_updated = datetime.fromtimestamp(float(ADDON.getSetting('last_update'))).strftime("%Y-%m-%d %H:%M") if ADDON.getSetting('last_update') else 'Never'

--- a/lib/inputstreamhelper/unicodehelper.py
+++ b/lib/inputstreamhelper/unicodehelper.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+''' Implements Unicode Helper functions '''
+from __future__ import absolute_import, division, unicode_literals
+
+
+def to_unicode(text, encoding='utf-8'):
+    ''' Force text to unicode '''
+    return text.decode(encoding) if isinstance(text, bytes) else text
+
+
+def from_unicode(text, encoding='utf-8'):
+    ''' Force unicode to text '''
+    import sys
+    if sys.version_info.major == 2 and isinstance(text, unicode):  # noqa: F821; pylint: disable=undefined-variable
+        return text.encode(encoding)
+    return text


### PR DESCRIPTION
This pull request fixes https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/102 and includes:
- remove kodi.six dependency
- replace `os.path.realpath(__file__)` with` xbmcaddon.Addon().getAddonInfo('path')` because it failed on `C:\Users\Björn` unicode path
- add unicodehelper file with conversion functions
- ensure global var ADDON_VERSION is reused
- convert to/from unicode when necessary for xbmc python2 functions
