### PR TITLE
Add a python setuptools setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ test/userdata/tmp/
 
 experiment/
 *.zip
+
+build/
+dist/
+lib/inputstreamhelper.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+from setuptools import setup, find_packages
+import os
+from xml.dom.minidom import parse
+
+project_dir = os.path.dirname(os.path.abspath(__file__))
+metadata = parse(os.path.join(project_dir, 'addon.xml'))
+addon_version = metadata.firstChild.getAttribute('version')
+addon_id = metadata.firstChild.getAttribute('id')
+
+setup(
+    name='inputstreamhelper',
+    version=addon_version,
+    url='https://github.com/tamland/kodi-plugin-routing',
+    author='Emil Svennesson',
+    description='Kodi InputStream Helper',
+    long_description=open(os.path.join(project_dir, 'README.md')).read(),
+    keywords='Kodi, plugin, inputstream, helper',
+    license='MIT',
+    package_dir = {'': 'lib'},
+    packages=find_packages('lib'),
+    zip_safe=False,
+)


### PR DESCRIPTION
This is very convenient for pulling in the module for automated testing.
Before this we have to include the module in our project, but using this
we can actually pull it directly from Github using:

**requirements.txt**
```
git+git://github.com/emilsvennesson/script.module.inputstreamhelper.git@master#egg=inputstreamhelper
```

This can be tested by doing adding this to requirements.txt:
```
git+git://github.com/dagwieers/script.module.inputstreamhelper.git@setup#egg=inputstreamhelper
```

And then run

```
$ sudo pip install -r requirements.txt
Collecting inputstreamhelper from
git+git://github.com/dagwieers/script.module.inputstreamhelper.git@setup#egg=inputstreamhelper
(from -r requirements.txt (line 7))
  Cloning git://github.com/dagwieers/script.module.inputstreamhelper.git (to setup)
to /tmp/pip-build-OMyYfj/inputstreamhelper
Installing collected packages: inputstreamhelper
  Running setup.py install for inputstreamhelper ... done
```