### PR TITLE
Rename "Troubleshooting" to "Expert"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,5 @@ clean:
 	@echo -e "$(white)=$(blue) Cleaning up$(reset)"
 	find . test/ -name '*.pyc' -type f -delete
 	find . -name '__pycache__' -type d -delete
-	find test/userdata/ -mindepth 1 -type d -delete
+	find test/userdata/temp/ -mindepth 1 -type d -delete
 	rm -rf .pytest_cache/ .tox/ *.log

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -278,8 +278,8 @@ msgstr ""
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
-msgstr "Fehlerbehebung"
+msgid "Expert"
+msgstr ""
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]Bei Deaktivierung könnte DRM Wiedergabe fehlschlagen![/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgid "Update frequency in days"
+msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "Entferne die Widevine CDM Bibliothek..."
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr ""
+msgid "Remove Widevine CDM library..."
+msgstr "Entferne die Widevine CDM Bibliothek..."

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -278,8 +278,8 @@ msgstr ""
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
-msgstr "Αντιμετώπιση προβλημάτων"
+msgid "Expert"
+msgstr ""
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]Όταν απενεργοποιηθεί, η αναπαραγωγή ροών με DRM μπορεί να αποτύχει![/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "(Επαν)εγκατάσταση της βιβλιοθήκης CDM..."
+msgid "Update frequency in days"
+msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "Αφαίρεση της βιβλιοθήκης CDM..."
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "(Επαν)εγκατάσταση της βιβλιοθήκης CDM..."
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr ""
+msgid "Remove Widevine CDM library..."
+msgstr "Αφαίρεση της βιβλιοθήκης CDM..."

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -278,7 +278,7 @@ msgstr ""
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
+msgid "Expert"
 msgstr ""
 
 msgctxt "#30901"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr ""
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
+msgid "Update frequency in days"
 msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr ""
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr ""
+
 msgctxt "#30911"
-msgid "Update frequency in days"
+msgid "Remove Widevine CDM library..."
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -278,8 +278,8 @@ msgstr "Veuillez signaler les problèmes à :\n - [COLOR yellow]{url}[/COLOR]"
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
-msgstr "Dépannage"
+msgid "Expert"
+msgstr ""
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]Lorsque qu'il est déactivé, la lecture de contenu DRM peut échouer![/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "(Re)installer la bibliothèque Widevine CDM..."
+msgid "Update frequency in days"
+msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "désinstaller la bibliothèque Widevine CDM..."
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "(Re)installer la bibliothèque Widevine CDM..."
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr ""
+msgid "Remove Widevine CDM library..."
+msgstr "désinstaller la bibliothèque Widevine CDM..."

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -278,7 +278,7 @@ msgstr ""
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
+msgid "Expert"
 msgstr ""
 
 msgctxt "#30901"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]Quando disabilitato, la riproduzione dei contenuti protetti da DRM potrebbe fallire[/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "(Re)installa Widevine CDM"
+msgid "Update frequency in days"
+msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "Rimuovi Widevine CDM"
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "(Re)installa Widevine CDM"
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr ""
+msgid "Remove Widevine CDM library..."
+msgstr "Rimuovi Widevine CDM"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -278,8 +278,8 @@ msgstr "Graag problemen melden op:\n - [COLOR yellow]{url}[/COLOR]"
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
-msgstr "Foutopsporing"
+msgid "Expert"
+msgstr "Expert"
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]Indien uitgeschakeld, kan de weergave van DRM-content mislukken![/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM (her)installeren..."
+msgid "Update frequency in days"
+msgstr "Update frequentie in dagen"
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "Widevine CDM verwijderen..."
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr "Tijdelijke download folder"
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "Widevine CDM (her)installeren..."
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr "Update frequentie in dagen"
+msgid "Remove Widevine CDM library..."
+msgstr "Widevine CDM verwijderen..."

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -278,8 +278,8 @@ msgstr "Пожалуйста, о проблемах сообщайте сюда:
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
-msgstr "Исправление проблем"
+msgid "Expert"
+msgstr ""
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]При отключении возможны проблемы с запуском DRM контента![/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "(Пере)установить модуль Widevine CDM..."
+msgid "Update frequency in days"
+msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "Удалить модуль Widevine CDM..."
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "(Пере)установить модуль Widevine CDM..."
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr ""
+msgid "Remove Widevine CDM library..."
+msgstr "Удалить модуль Widevine CDM..."

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -278,8 +278,8 @@ msgstr ""
 
 ### SETTINGS
 msgctxt "#30900"
-msgid "Troubleshooting"
-msgstr "Felsökning"
+msgid "Expert"
+msgstr ""
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -294,17 +294,17 @@ msgid "[I]When disabled, DRM playback may fail![/I]"
 msgstr "[I]DRM-uppspelning kan misslyckas vid inaktivering![/I]"
 
 msgctxt "#30905"
-msgid "(Re)install Widevine CDM library..."
-msgstr "(Om)installera Widevine CDM-biblioteket..."
+msgid "Update frequency in days"
+msgstr ""
 
 msgctxt "#30907"
-msgid "Remove Widevine CDM library..."
-msgstr "Ta bort Widevine CDM-biblioteket..."
-
-msgctxt "#30909"
 msgid "Temporary download directory"
 msgstr ""
 
+msgctxt "#30909"
+msgid "(Re)install Widevine CDM library..."
+msgstr "(Om)installera Widevine CDM-biblioteket..."
+
 msgctxt "#30911"
-msgid "Update frequency in days"
-msgstr ""
+msgid "Remove Widevine CDM library..."
+msgstr "Ta bort Widevine CDM-biblioteket..."

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,13 +3,15 @@
     <setting id="last_update" value="" visible="false"/>
     <setting id="version" value="" visible="false"/>
     <setting id="chromeos_version" value="" visible="false"/>
-    <category label="30900"> <!-- Troubleshooting -->
+    <category label="30900"> <!-- Expert -->
         <setting label="30901" type="action" id="info" action="RunScript(script.module.inputstreamhelper, info)"/>
+        <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
         <setting label="30904" type="text" id="warning" enable="false"/> <!-- disabled_warning -->
-        <setting label="30905" help="30906" type="action" id="install_widevine" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android + eq(-2,false)"/>
-        <setting label="30907" help="30908" type="action" id="remove_widevine" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android + eq(-3,false)"/>
-        <setting label="30909" help="30910" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper"/>
-        <setting label="30911" help="30912" type="number" id="update_frequency" default="14"/>
+        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)"/>
+        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper"/>
+        <setting type="sep"/>
+        <setting label="30909" help="30910" type="action" id="install_widevine" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
+        <setting label="30911" help="30912" type="action" id="remove_widevine" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
     </category>
 </settings>


### PR DESCRIPTION
It seems most other add-ons use "Expert" which better fits this section
here as well.

Also, even (or especially) when InputStream Helper is disabled the user
may want to install or remove Widevine. So it does not make sense to
disable this functionality when InputStream Helper is disabled.

I also added separators since having more than one section seems worse
than this.

This PR includes:
- Reorganization of settings
- Rename "Troubleshooting" into "Expert"
- Turn frequency into slider
- Restore default frequency from "14" to "31"