### PR TITLE
Disable all options on Android

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,9 +8,9 @@
         <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
         <setting label="30904" type="text" id="warning" enable="false"/> <!-- disabled_warning -->
-        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)"/>
-        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper"/>
-        <setting type="sep"/>
+        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)" visible="!system.platform.android"/>
+        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="!system.platform.android"/>
+        <setting type="sep" visible="!system.platform.android"/>
         <setting label="30909" help="30910" type="action" id="install_widevine" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
         <setting label="30911" help="30912" type="action" id="remove_widevine" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
     </category>


### PR DESCRIPTION
Sadly I didn't think of this before and noticed this just yet on Android.

There is no need for having any of the inputstreamhelper options on Android.