### PR TITLE
Translate path and compare before moving

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -198,7 +198,8 @@ class Helper:
         old_temp_path = self._temp_path()
 
         set_setting('temp_path', new_temp_path)
-        shutil.move(old_temp_path, new_temp_path)
+        if old_temp_path != self._temp_path():
+            shutil.move(old_temp_path, self._temp_path())
 
     def _helper_disabled(self):
         """Return if inputstreamhelper has been disabled in settings.xml."""


### PR DESCRIPTION
So we don't have to translate the path ourselves, this is what
_temp_path() will do for us.

So after writing the (new?) setting we can compare it to the old setting
to ensure it conforms to the same manipulations.

This fixes #186