### PR TITLE
backup and local rollback

### DIFF
--- a/lib/inputstreamhelper/api.py
+++ b/lib/inputstreamhelper/api.py
@@ -20,6 +20,9 @@ def run(params):
                 check_inputstream(params[2], drm=params[3])
         elif params[1] == 'info':
             info_dialog()
+        elif params[1] == 'rollback':
+            rollback()
+
     elif len(params) > 4:
         log('invalid API call, too many parameters')
     else:
@@ -44,3 +47,8 @@ def widevine_remove():
 def info_dialog():
     ''' The API interface to show an info Dialog '''
     Helper('mpd', drm='widevine').info_dialog()
+
+
+def rollback():
+    ''' The API interface to rollback Widevine CDM '''
+    Helper('mpd', drm='widevine').rollback_libwv()

--- a/lib/inputstreamhelper/config.py
+++ b/lib/inputstreamhelper/config.py
@@ -74,7 +74,7 @@ WIDEVINE_LICENSE_FILE = 'LICENSE.txt'
 
 WIDEVINE_MANIFEST_FILE = 'manifest.json'
 
-WIDEVINE_CONFIG_NAME = 'widevine_config.json'
+WIDEVINE_CONFIG_NAME = 'manifest.json'
 
 CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.conf'
 

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -57,6 +57,14 @@ def ok_dialog(heading='', message=''):
     return Dialog().ok(heading=heading, line1=message)
 
 
+def select_dialog(heading='', opt_list=None, autoclose=False, preselect=None, useDetails=False): # pylint: disable=invalid-name
+    ''' Show Kodi's Select dialog '''
+    from xbmcgui import Dialog
+    if not heading:
+        heading = ADDON.getAddonInfo('name')
+    return Dialog().select(heading=heading, opt_list=opt_list, autoclose=autoclose, preselect=preselect, useDetails=useDetails)
+
+
 def progress_dialog():
     ''' Show Kodi's Progress dialog '''
     from xbmcgui import DialogProgress
@@ -156,7 +164,7 @@ def get_proxies():
 
 
 def get_userdata_path():
-    ''' Return the profile's userdata path '''
+    ''' Return the addon's addon_data path '''
     return translate_path(ADDON.getAddonInfo('profile'))
 
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -229,6 +229,14 @@ msgctxt "#30055"
 msgid "There is not enough free disk space in the current temporary directory. Would you like to specify a different one to temporarily use for the Chrome OS Recovery Image (e.g. on a USB)?"
 msgstr ""
 
+msgctxt "#30056"
+msgid "No backups found!"
+msgstr ""
+
+msgctxt "#30057"
+msgid "Choose a backup to restore"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
@@ -307,4 +315,12 @@ msgstr ""
 
 msgctxt "#30911"
 msgid "Remove Widevine CDM library..."
+msgstr ""
+
+msgctxt "#30913"
+msgid "Number of backups"
+msgstr ""
+
+msgctxt "#30915"
+msgid "Rollback Widevine CDM library..."
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,8 +10,10 @@
         <setting label="30904" type="text" id="warning" enable="false"/> <!-- disabled_warning -->
         <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)" visible="!system.platform.android"/>
         <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="!system.platform.android"/>
+        <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="!system.platform.android"/>
         <setting type="sep" visible="!system.platform.android"/>
         <setting label="30909" help="30910" type="action" id="install_widevine" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
         <setting label="30911" help="30912" type="action" id="remove_widevine" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
+        <setting label="30915" help="30916" type="action" id="rollback" action="RunScript(script.module.inputstreamhelper, rollback)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
     </category>
 </settings>

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -34,6 +34,15 @@ class Dialog:
         ''' A stub implementation for the xbmcgui Dialog class info() method '''
 
     @staticmethod
+    def select(heading, opt_list, autoclose=0, preselect=None, useDetails=False):
+        ''' A stub implementation for the xbmcgui Dialog class select() method '''
+        if preselect is None:
+            preselect = []
+        heading = kodi_to_ansi(heading)
+        print('\033[37;44;1mSELECT:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, ', '.join(opt_list)))
+        return -1
+
+    @staticmethod
     def multiselect(heading, options, autoclose=0, preselect=None, useDetails=False):  # pylint: disable=useless-return
         ''' A stub implementation for the xbmcgui Dialog class multiselect() method '''
         if preselect is None:

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -6,6 +6,7 @@
 # pylint: disable=invalid-name
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+from shutil import copyfile
 import os
 
 
@@ -29,6 +30,11 @@ def Stat(path):
             return self._stat.st_mtime
 
     return stat(path)
+
+
+def copy(src, dst):
+    ''' A reimplementation of the xbmcvfs mkdir() function '''
+    return copyfile(src, dst) == dst
 
 
 def delete(path):


### PR DESCRIPTION
This adds the option to automatically create a backup of the installed lib (on update/reinstall or rollback) and rollback, keeping multiple backups according to the setting 'backups'.

This does not yet implement online rollback or pinning, but I think we should discuss (in #165) whether pinning is actually any different from disabling.