### PR TITLE
Add InputStream Helper information to logs

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -24,7 +24,7 @@ import xbmc
 from xbmcaddon import Addon
 from xbmcgui import Dialog, DialogProgress
 import xbmcvfs
-from .kodiutils import execute_jsonrpc, get_addon_info, get_proxies, get_setting, localize, log, set_setting, translate_path
+from .kodiutils import execute_jsonrpc, get_addon_info, get_proxies, get_setting, kodi_to_ascii, localize, log, set_setting, translate_path
 from .unicodehelper import to_unicode
 
 # NOTE: Work around issue caused by platform still using os.popen()
@@ -966,4 +966,5 @@ class Helper:
 
         text += localize(30830, url=config.ISSUE_URL)  # Report issues
 
+        log('\n{info}'.format(info=kodi_to_ascii(text)), level=xbmc.LOGNOTICE)
         Dialog().textviewer(localize(30901), text)

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -129,6 +129,20 @@ def execute_jsonrpc(payload):
     return json.loads(response)
 
 
-def log(msg, **kwargs):
+def log(msg, level=xbmc.LOGDEBUG, **kwargs):
     ''' InputStream Helper log method '''
-    xbmc.log(msg=from_unicode('[{addon}]: {msg}'.format(addon=get_addon_info('id'), msg=msg.format(**kwargs))), level=xbmc.LOGDEBUG)
+    xbmc.log(msg=from_unicode('[{addon}]: {msg}'.format(addon=get_addon_info('id'), msg=msg.format(**kwargs))), level=level)
+
+
+def kodi_to_ascii(string):
+    ''' Convert Kodi format tags to ascii '''
+    if string is None:
+        return None
+    string = string.replace('[B]', '')
+    string = string.replace('[/B]', '')
+    string = string.replace('[I]', '')
+    string = string.replace('[/I]', '')
+    string = string.replace('[COLOR gray]', '')
+    string = string.replace('[COLOR yellow]', '')
+    string = string.replace('[/COLOR]', '')
+    return string


### PR DESCRIPTION
Since making a screenshot is harder than copy&pasting logs, it is
probably better to log this information as well when it is requested.

This may help in troubleshooting.

This relates to #206 