### PR TITLE
Add Widevine version as built-in

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -1061,17 +1061,19 @@ class Helper:
         text += ' - ' + localize(30812, version=self._inputstream_version(), state=istream_state) + '\n'
         text += '\n'
 
-        if system_os() != 'Android':
-            text += localize(30820) + '\n'  # Widevine information
+        text += ' - ' + localize(30820) + '\n'  # Widevine information
+        if system_os() == 'Android':
+            text += ' - ' + localize(30821) + '\n'
+        else:
             from datetime import datetime
             wv_updated = datetime.fromtimestamp(float(get_setting('last_update'))).strftime("%Y-%m-%d %H:%M") if get_setting('last_update') else 'Never'
-            text += ' - ' + localize(30821, version=self._get_lib_version(self._widevine_path()), date=wv_updated) + '\n'
-            text += ' - ' + localize(30822, path=self._ia_cdm_path()) + '\n'
+            text += ' - ' + localize(30822, version=self._get_lib_version(self._widevine_path()), date=wv_updated) + '\n'
+            text += ' - ' + localize(30823, path=self._ia_cdm_path()) + '\n'
 
             if self._arch() in ('arm', 'arm64'):  # Chrome OS version
-                text += ' - ' + localize(30823, version=get_setting('chromeos_version')) + '\n'
+                text += ' - ' + localize(30824, version=get_setting('chromeos_version')) + '\n'
 
-            text += '\n'
+        text += '\n'
 
         text += localize(30830, url=config.ISSUE_URL)  # Report issues
 

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine Informationen[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine Version: [B]{version}[/B] [COLOR gray](zuletzt aktualisiert am [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM Pfad: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS Version: [B]{version}[/B]"
 

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -260,7 +260,7 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine Informationen[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -260,7 +260,7 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Πληροφορίες Widevine[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Πληροφορίες Widevine[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Έκδοση Widevina: [B]{version}[/B] [COLOR gray](τελευταία ενημερωση [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Διαδρομη CDM του Widevine: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Έκδοση του Chrome OS: [B]{version}[/B]"
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -268,14 +268,18 @@ msgid "[B]Widevine information[/B]"
 msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgid "Widevine version: [B]Built-in[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine CDM path: [B]{path}[/B]"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr ""
 
 msgctxt "#30823"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr ""
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -268,7 +268,7 @@ msgid "[B]Widevine information[/B]"
 msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Information Widevine[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Version Widevine : [B]{version}[/B] [COLOR gray](mise à jour le [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Emplacement de Widevine CDM : [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Version de ChromeOS : [B]{version}[/B]"
 

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -260,7 +260,7 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Information Widevine[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -268,14 +268,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine informacije[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built into Android[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine verzija: [B]{version}[/B] [COLOR gray](zadnja nadogradnja [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM mapa: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS verzija: [B]{version}[/B]"
 

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -268,14 +268,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine információ[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built into Android[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine verzió: [B]{version}[/B] [COLOR gray](utolsó frissítés [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM elérési út: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS verzió: [B]{version}[/B]"
 

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine info[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine: [B]{version}[/B] [COLOR gray](aggiornato il [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS: [B]{version}[/B]"
 

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -260,7 +260,7 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine info[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -268,14 +268,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine情報[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built into Android[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevineバージョン：[B]{version}[/B] [COLOR gray](直近更新日[B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM パス: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS バージョン： [B]{version}[/B]"
 

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -268,14 +268,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine 정보[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built into Android[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine 버전: [B]{version}[/B] [COLOR gray]([B]{date}[/B]에 마지막으로 업데이트)[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM 경로: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS 버전: [B]{version}[/B]"
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -260,8 +260,8 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Informatie over Widevine[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
-msgstr "Widevine versie: [B]Ingebouwd[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
+msgstr "Widevine versie: [B]Ingebouwd in Android[/B]"
 
 msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Informatie over Widevine[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr "Widevine versie: [B]Ingebouwd[/B]"
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine versie: [B]{version}[/B] [COLOR gray](voor het laatst geüpdatet op [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM pad: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS versie: [B]{version}[/B]"
 

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Информация о Widevine[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Версия Widevine: [B]{version}[/B] [COLOR gray](последнее обновление [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Путь к Widevine CDM: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Версия Chrome OS: [B]{version}[/B]"
 

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -260,7 +260,7 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Информация о Widevine[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -260,7 +260,7 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine-information[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built-in[/B]"
+msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -260,14 +260,18 @@ msgid "[B]Widevine information[/B]"
 msgstr "[B]Widevine-information[/B]"
 
 msgctxt "#30821"
+msgid "Widevine version: [B]Built-in[/B]"
+msgstr ""
+
+msgctxt "#30822"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine-version: [B]{version}[/B] [COLOR gray](senast uppdaterad [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30822"
+msgctxt "#30823"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM-sökväg: [B]{path}[/B]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS-version: [B]{version}[/B]"
 


### PR DESCRIPTION
Rather than leaving Widevine information out of the information pane, we
should display it as 'built-in'. This will be less confusing.

This relates to #206