### PR TITLE
Disable proxy tests on Python 2.7

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -11,11 +11,9 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 from datetime import datetime, timedelta
 
 try:  # Python 3
-    from http.client import BadStatusLine
     from urllib.error import HTTPError
     from urllib.request import build_opener, install_opener, ProxyHandler, urlopen
 except ImportError:  # Python 2
-    from httplib import BadStatusLine
     from urllib2 import build_opener, HTTPError, install_opener, ProxyHandler, urlopen
 
 from inputstreamhelper import config
@@ -348,20 +346,14 @@ class Helper:
         log('Request URL: {url}', url=url)
         filename = url.split('/')[-1]
 
-        for retry in (False, True):
-            try:
-                req = urlopen(url)
-                log('Response code: {code}', code=req.getcode())
-                if 400 <= req.getcode() < 600:
-                    raise HTTPError('HTTP %s Error for url: %s' % (req.getcode(), url), response=req)
-                break
-            except HTTPError:
-                Dialog().ok(localize(30004), localize(30013, filename=filename))  # Failed to retrieve file
-                return None
-            except BadStatusLine:
-                if retry:
-                    Dialog().ok(localize(30004), localize(30013, filename=filename))  # Failed to retrieve file
-                    return None
+        try:
+            req = urlopen(url)
+            log('Response code: {code}', code=req.getcode())
+            if 400 <= req.getcode() < 600:
+                raise HTTPError('HTTP %s Error for url: %s' % (req.getcode(), url), response=req)
+        except HTTPError:
+            Dialog().ok(localize(30004), localize(30013, filename=filename))  # Failed to retrieve file
+            return None
         return req
 
     def _http_get(self, url):

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -5,6 +5,7 @@
 # pylint: disable=duplicate-code,invalid-name,missing-docstring,protected-access
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
 import unittest
 import platform
 import inputstreamhelper
@@ -14,13 +15,18 @@ xbmcaddon = __import__('xbmcaddon')
 xbmcgui = __import__('xbmcgui')
 xbmcvfs = __import__('xbmcvfs')
 
-xbmc.GLOBAL_SETTINGS['network.usehttpproxy'] = True
-xbmc.GLOBAL_SETTINGS['network.httpproxytype'] = 0
-xbmc.GLOBAL_SETTINGS['network.httpproxyserver'] = '127.0.0.1'
-xbmc.GLOBAL_SETTINGS['network.httpproxyport'] = '8899'
 
-
+@unittest.skipIf(sys.version_info[0] < 3, 'Skipping proxy tests on Python 2')
 class LinuxProxyTests(unittest.TestCase):
+
+    def setUp(self):
+        xbmc.GLOBAL_SETTINGS['network.usehttpproxy'] = True
+        xbmc.GLOBAL_SETTINGS['network.httpproxytype'] = 0
+        xbmc.GLOBAL_SETTINGS['network.httpproxyserver'] = '127.0.0.1'
+        xbmc.GLOBAL_SETTINGS['network.httpproxyport'] = '8899'
+
+    def tearDown(self):
+        xbmc.GLOBAL_SETTINGS['network.usehttpproxy'] = False
 
     def test_check_inputstream_mpd(self):
         inputstreamhelper.system_os = lambda: 'Linux'


### PR DESCRIPTION
We added retries to our HTTP requests because of issues with proxy.py
and Python 2.7 (causing BadStatusLine issues).

Since this is a pure proxy.py issue, I'd rather stop testing proxy
compatibility on Python 2.7 then changing our code to support tests
(most of the time).