### PR TITLE
Use LANG=C for subprocesses

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -198,7 +198,7 @@ class Helper:
         """Check whether cmd exists on system."""
         # https://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
         import subprocess
-        return subprocess.call('type ' + cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+        return subprocess.call(['type ' + cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
 
     def _update_temp_path(self, new_temp_path):
         """"Updates temp_path and merges files."""

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -279,13 +279,15 @@ class Helper:
         ''' Run subprocess command and return if it succeeds as a bool '''
         from .unicodehelper import to_unicode
         import subprocess
+        env = os.environ.copy()
+        env['LANG'] = 'C'
         output = ''
         success = False
         if sudo and os.getuid() != 0 and self._cmd_exists('sudo'):
             cmd.insert(0, 'sudo')
 
         try:
-            output = to_unicode(subprocess.check_output(cmd, shell=shell, stderr=subprocess.STDOUT))
+            output = to_unicode(subprocess.check_output(cmd, shell=shell, stderr=subprocess.STDOUT, env=env))
         except subprocess.CalledProcessError as error:
             output = error.output
             log('{cmd} cmd failed.', cmd=cmd)


### PR DESCRIPTION
If `LANG=de_DE.UTF-8` is used, for example, the command output of `fdisk -l` will contain unicode characters. This is problematic because Kodi's logging mechanism crashes and the command's output parsing is not reliable.

When `LANG=C` is used, the commands' output will consist of ASCII-only characters, which is nice.

See #210 for an example of the resulting error message when a unicode string is given to the `log()` function. As every command output is given to `log()`, this means bad things.