### PR TITLE
Remove id from settings entries

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,16 +4,16 @@
     <setting id="version" value="" visible="false"/>
     <setting id="chromeos_version" value="" visible="false"/>
     <category label="30900"> <!-- Expert -->
-        <setting label="30901" type="action" id="info" action="RunScript(script.module.inputstreamhelper, info)"/>
+        <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
-        <setting label="30904" type="text" id="warning" enable="false"/> <!-- disabled_warning -->
+        <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
         <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)" visible="!system.platform.android"/>
         <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="!system.platform.android"/>
         <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="!system.platform.android"/>
         <setting type="sep" visible="!system.platform.android"/>
-        <setting label="30909" help="30910" type="action" id="install_widevine" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
-        <setting label="30911" help="30912" type="action" id="remove_widevine" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
-        <setting label="30915" help="30916" type="action" id="rollback" action="RunScript(script.module.inputstreamhelper, rollback)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
+        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
+        <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
+        <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
     </category>
 </settings>


### PR DESCRIPTION
We currently have the id attribute added to entries in the settings.xml
that don't need it. And this results in entries in the user's settings
for things that don't store values.

So we ought to remove them to keep the user settings clean (for new users).