### PR TITLE
Support vendor widevine library

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -1074,7 +1074,7 @@ class Helper:
         if system_os() == 'Android':
             text += ' - ' + localize(30821) + '\n'
         elif self._has_vendor_widevine():
-            text += ' - ' + localize(30822) + '\n'
+            text += ' - ' + localize(30822, version=self._get_lib_version(self._widevine_path())) + '\n'
         else:
             from datetime import datetime
             wv_updated = datetime.fromtimestamp(float(get_setting('last_update'))).strftime("%Y-%m-%d %H:%M") if get_setting('last_update') else 'Never'

--- a/lib/inputstreamhelper/api.py
+++ b/lib/inputstreamhelper/api.py
@@ -24,7 +24,7 @@ def run(params):
             rollback()
 
     elif len(params) > 4:
-        log('invalid API call, too many parameters')
+        log(4, 'invalid API call, too many parameters')
     else:
         ADDON.openSettings()
 

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -7,7 +7,7 @@ import xbmc
 from xbmcaddon import Addon
 from .unicodehelper import from_unicode, to_unicode
 
-ADDON = Addon()
+ADDON = Addon('script.module.inputstreamhelper')
 
 
 class SafeDict(dict):

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr "Widevine Version: [B]In Android eingebaut[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr "Widevine Version: [B]In Android eingebaut[/B]"
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine Version: [B]{version}[/B] [COLOR gray](zuletzt aktualisiert am [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM Pfad: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS Version: [B]{version}[/B]"
 

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Έκδοση Widevina: [B]{version}[/B] [COLOR gray](τελευταία ενημερωση [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Διαδρομη CDM του Widevine: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Έκδοση του Chrome OS: [B]{version}[/B]"
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
 msgstr ""
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
+msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr ""
 
 msgctxt "#30824"
+msgid "Widevine CDM path: [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr ""
 

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Version Widevine : [B]{version}[/B] [COLOR gray](mise à jour le [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Emplacement de Widevine CDM : [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Version de ChromeOS : [B]{version}[/B]"
 

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine verzija: [B]{version}[/B] [COLOR gray](zadnja nadogradnja [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM mapa: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS verzija: [B]{version}[/B]"
 

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine verzió: [B]{version}[/B] [COLOR gray](utolsó frissítés [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM elérési út: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS verzió: [B]{version}[/B]"
 

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine: [B]{version}[/B] [COLOR gray](aggiornato il [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS: [B]{version}[/B]"
 

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevineバージョン：[B]{version}[/B] [COLOR gray](直近更新日[B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM パス: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS バージョン： [B]{version}[/B]"
 

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine 버전: [B]{version}[/B] [COLOR gray]([B]{date}[/B]에 마지막으로 업데이트)[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM 경로: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS 버전: [B]{version}[/B]"
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -272,8 +272,8 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr "Widevine versie: [B]Ingebouwd in Android[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
-msgstr "Widevine versie: [B]Aangeleverd door vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
+msgstr "Widevine versie: [B]{version} [COLOR gray](aangeleverd door vendor)[/COLOR][/B]"
 
 msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr "Widevine versie: [B]Ingebouwd in Android[/B]"
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr "Widevine versie: [B]Aangeleverd door vendor[/B]"
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine versie: [B]{version}[/B] [COLOR gray](voor het laatst geüpdatet op [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM pad: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS versie: [B]{version}[/B]"
 

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Версия Widevine: [B]{version}[/B] [COLOR gray](последнее обновление [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Путь к Widevine CDM: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Версия Chrome OS: [B]{version}[/B]"
 

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -272,14 +272,18 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
+msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgstr ""
+
+msgctxt "#30823"
 msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
 msgstr "Widevine-version: [B]{version}[/B] [COLOR gray](senast uppdaterad [B]{date}[/B])[/COLOR]"
 
-msgctxt "#30823"
+msgctxt "#30824"
 msgid "Widevine CDM path: [B]{path}[/B]"
 msgstr "Widevine CDM-sökväg: [B]{path}[/B]"
 
-msgctxt "#30824"
+msgctxt "#30825"
 msgid "Chrome OS version: [B]{version}[/B]"
 msgstr "Chrome OS-version: [B]{version}[/B]"
 

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -272,7 +272,7 @@ msgid "Widevine version: [B]Built into Android[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]Supplied by vendor[/B]"
+msgid "Widevine version: [B]{version} [COLOR gray](supplied by vendor)[/COLOR][/B]"
 msgstr ""
 
 msgctxt "#30823"

--- a/test/test_vendor.py
+++ b/test/test_vendor.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pylint: disable=duplicate-code,invalid-name,missing-docstring,protected-access
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import os
+import unittest
+import platform
+import inputstreamhelper
+
+xbmc = __import__('xbmc')
+xbmcaddon = __import__('xbmcaddon')
+xbmcgui = __import__('xbmcgui')
+xbmcvfs = __import__('xbmcvfs')
+
+
+class LinuxVendorTests(unittest.TestCase):
+
+    def setUp(self):
+        open('test/cdm/libwidevinecdm_vendor.so', 'w').write('Linux')
+
+    def tearDown(self):
+        os.unlink('test/cdm/libwidevinecdm_vendor.so')
+
+    def test_check_inputstream_mpd(self):
+        inputstreamhelper.system_os = lambda: 'Linux'
+        platform.machine = lambda: 'arm'
+        is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+        is_helper.remove_widevine()
+        is_installed = is_helper.check_inputstream()
+        self.assertTrue(is_installed, True)
+
+    def test_check_inputstream_hls_again(self):
+        inputstreamhelper.system_os = lambda: 'Linux'
+        platform.machine = lambda: 'arm'
+        is_helper = inputstreamhelper.Helper('hls', drm='com.widevine.alpha')
+        is_installed = is_helper.check_inputstream()
+        self.assertTrue(is_installed, True)
+
+
+class WindowsVendorTests(unittest.TestCase):
+
+    def setUp(self):
+        open('test/cdm/widevinecdm_vendor.dll', 'w').write('Windows')
+
+    def tearDown(self):
+        os.unlink('test/cdm/widevinecdm_vendor.dll')
+
+    def test_check_inputstream_hls(self):
+        inputstreamhelper.system_os = lambda: 'Windows'
+        platform.machine = lambda: 'AMD64'
+        platform.architecture = lambda: ['64bit', '']
+        is_helper = inputstreamhelper.Helper('hls', drm='com.widevine.alpha')
+        is_installed = is_helper.check_inputstream()
+        self.assertTrue(is_installed, True)
+
+    def test_check_inputstream_mpd_again(self):
+        inputstreamhelper.system_os = lambda: 'Windows'
+        platform.machine = lambda: 'AMD64'
+        platform.architecture = lambda: ['64bit', '']
+        is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+        is_installed = is_helper.check_inputstream()
+        self.assertTrue(is_installed, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_vendor.py
+++ b/test/test_vendor.py
@@ -20,7 +20,8 @@ xbmcvfs = __import__('xbmcvfs')
 class LinuxVendorTests(unittest.TestCase):
 
     def setUp(self):
-        open('test/cdm/libwidevinecdm_vendor.so', 'w').write('Linux\n1.2.3.4')
+        with open('test/cdm/libwidevinecdm_vendor.so', 'w') as fdesc:
+            fdesc.write('Linux\n1.2.3.4')
 
     def tearDown(self):
         os.unlink('test/cdm/libwidevinecdm_vendor.so')
@@ -48,7 +49,8 @@ class LinuxVendorTests(unittest.TestCase):
 class WindowsVendorTests(unittest.TestCase):
 
     def setUp(self):
-        open('test/cdm/widevinecdm_vendor.dll', 'w').write('Windows\n1.2.3.4')
+        with open('test/cdm/widevinecdm_vendor.dll', 'w') as fdesc:
+            fdesc.write('Windows\n1.2.3.4')
 
     def tearDown(self):
         os.unlink('test/cdm/widevinecdm_vendor.dll')
@@ -66,6 +68,35 @@ class WindowsVendorTests(unittest.TestCase):
         platform.machine = lambda: 'AMD64'
         platform.architecture = lambda: ['64bit', '']
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+        is_installed = is_helper.check_inputstream()
+        self.assertTrue(is_installed, True)
+
+    @staticmethod
+    def test_about():
+        default.run(['default.py', 'info'])
+
+
+class DarwinVendorTests(unittest.TestCase):
+
+    def setUp(self):
+        with open('test/cdm/libwidevinecdm_vendor.dylib', 'w') as fdesc:
+            fdesc.write('macOS\n1.2.3.4')
+
+    def tearDown(self):
+        os.unlink('test/cdm/libwidevinecdm_vendor.dylib')
+
+    def test_check_inputstream_mpd(self):
+        inputstreamhelper.system_os = lambda: 'Darwin'
+        platform.machine = lambda: 'x86_64'
+        is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+        is_helper.remove_widevine()
+        is_installed = is_helper.check_inputstream()
+        self.assertTrue(is_installed, True)
+
+    def test_check_inputstream_hls_again(self):
+        inputstreamhelper.system_os = lambda: 'Darwin'
+        platform.machine = lambda: 'x86_64'
+        is_helper = inputstreamhelper.Helper('hls', drm='com.widevine.alpha')
         is_installed = is_helper.check_inputstream()
         self.assertTrue(is_installed, True)
 

--- a/test/test_vendor.py
+++ b/test/test_vendor.py
@@ -9,6 +9,7 @@ import os
 import unittest
 import platform
 import inputstreamhelper
+import default
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -19,7 +20,7 @@ xbmcvfs = __import__('xbmcvfs')
 class LinuxVendorTests(unittest.TestCase):
 
     def setUp(self):
-        open('test/cdm/libwidevinecdm_vendor.so', 'w').write('Linux')
+        open('test/cdm/libwidevinecdm_vendor.so', 'w').write('Linux\n1.2.3.4')
 
     def tearDown(self):
         os.unlink('test/cdm/libwidevinecdm_vendor.so')
@@ -39,11 +40,15 @@ class LinuxVendorTests(unittest.TestCase):
         is_installed = is_helper.check_inputstream()
         self.assertTrue(is_installed, True)
 
+    @staticmethod
+    def test_about():
+        default.run(['default.py', 'info'])
+
 
 class WindowsVendorTests(unittest.TestCase):
 
     def setUp(self):
-        open('test/cdm/widevinecdm_vendor.dll', 'w').write('Windows')
+        open('test/cdm/widevinecdm_vendor.dll', 'w').write('Windows\n1.2.3.4')
 
     def tearDown(self):
         os.unlink('test/cdm/widevinecdm_vendor.dll')
@@ -63,6 +68,10 @@ class WindowsVendorTests(unittest.TestCase):
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
         is_installed = is_helper.check_inputstream()
         self.assertTrue(is_installed, True)
+
+    @staticmethod
+    def test_about():
+        default.run(['default.py', 'info'])
 
 
 if __name__ == '__main__':

--- a/test/test_vendor.py
+++ b/test/test_vendor.py
@@ -2,7 +2,7 @@
 # Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# pylint: disable=duplicate-code,invalid-name,missing-docstring,protected-access
+# pylint: disable=invalid-name,missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -25,9 +25,21 @@ def Stat(path):
             ''' The constructor xbmcvfs stat class '''
             self._stat = os.stat(path)
 
+        def st_dev(self):
+            ''' The xbmcvfs stat class st_dev method '''
+            return self._stat.st_dev
+
+        def st_ino(self):
+            ''' The xbmcvfs stat class st_ino method '''
+            return self._stat.st_ino
+
         def st_mtime(self):
             ''' The xbmcvfs stat class st_mtime method '''
             return self._stat.st_mtime
+
+        def st_size(self):
+            ''' The xbmcvfs stat class st_size method '''
+            return self._stat.st_size
 
     return stat(path)
 

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -18,7 +18,7 @@ def File(path, flags='r'):
 def Stat(path):
     ''' A reimplementation of the xbmcvfs Stat() function '''
 
-    class stat:  # pylint: disable=too-few-public-methods
+    class stat:
         ''' A reimplementation of the xbmcvfs stat class '''
 
         def __init__(self, path):


### PR DESCRIPTION
This adds support for a vendor-supported Widevine library.

**TODO:**
- Show actual version, not stored version
- Update stored version
- Get timestamp from library to show in info pane
- Do not show Chrome OS information when using vendor library
- Disable settings/operations

This fixes #229 