### PR TITLE
Use binary regex on binary lib

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -243,10 +243,11 @@ class Helper:
             return '(Not found)'
         import re
         with open(path, 'rb') as library:
-            match = re.search(r'[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+', str(library.read()))
+            match = re.search(br'[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+', library.read())
         if not match:
             return '(Undetected)'
-        return match.group(0).lstrip('0')
+        from .utils import to_unicode
+        return to_unicode(match.group(0))
 
     def _chromeos_offset(self, bin_path):
         """Calculate the Chrome OS losetup start offset using fdisk/parted."""


### PR DESCRIPTION
It's more efficient to use a binary regex when looking for something in a binary file. We only need to convert to a unicode string if something is found.
This fixes https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/250