### PR TITLE
Fix select_dialog function

### DIFF
--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -67,12 +67,12 @@ def ok_dialog(heading='', message=''):
     return Dialog().ok(heading=heading, line1=message)
 
 
-def select_dialog(heading='', opt_list=None, autoclose=False, preselect=None, useDetails=False):  # pylint: disable=invalid-name
+def select_dialog(heading='', opt_list=None, autoclose=0, preselect=-1, useDetails=False):  # pylint: disable=invalid-name
     """Show Kodi's Select dialog"""
     from xbmcgui import Dialog
     if not heading:
         heading = ADDON.getAddonInfo('name')
-    return Dialog().select(heading=heading, opt_list=opt_list, autoclose=autoclose, preselect=preselect, useDetails=useDetails)
+    return Dialog().select(heading, opt_list, autoclose=autoclose, preselect=preselect, useDetails=useDetails)
 
 
 def progress_dialog():

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -62,10 +62,8 @@ class Dialog:
         """A stub implementation for the xbmcgui Dialog class info() method"""
 
     @staticmethod
-    def select(heading, opt_list, autoclose=0, preselect=None, useDetails=False):
+    def select(heading, opt_list, autoclose=0, preselect=-1, useDetails=False):
         """A stub implementation for the xbmcgui Dialog class select() method"""
-        if preselect is None:
-            preselect = []
         heading = kodi_to_ansi(heading)
         print('\033[37;44;1mSELECT:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, ', '.join(opt_list)))
         return -1


### PR DESCRIPTION
`select_dialog` was broken, this pull request makes it functional. (function is used for restoring an earlier Widevine CDM library)