### PR TITLE
Change OSError to AttributeError

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -603,7 +603,7 @@ class Helper:
 
             try:
                 os.link(backup_fpath, install_fpath)
-            except OSError:
+            except AttributeError:
                 copy(backup_fpath, install_fpath)
 
         log('Installed CDM version {version} from backup', version=version)


### PR DESCRIPTION
It seems using the missing os.link in Python2 on Windows gives an AttributeError instead of OSError. This commit corrects that. See https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/256#issuecomment-582587377