### PR TITLE
Going sudoless with udisksctl

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,3 +11,4 @@ disable=
     too-many-locals,
     too-many-return-statements,
     unexpected-keyword-arg,
+    too-many-instance-attributes,


### PR DESCRIPTION
With this commit, there is no need on Raspbian and probably other ARM Linux Desktops to enable passwordless sudo, as long as udisks2 is installed and loop is built into the kernel.

I tested this on x86 Linux Desktop, RPi4 LibreELEC (both mainly to make sure I didn't break anything else) and RPi4 Raspbian (as user pi, but with nopasswd disabled) and didn't find any issues.

This would resolve #246 