### PR TITLE
Show unsupported architecture in pop-up

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -455,7 +455,7 @@ class Helper:
         """Checks if Widevine is supported on the architecture/operating system/Kodi version."""
         if self._arch() not in config.WIDEVINE_SUPPORTED_ARCHS:
             log('Unsupported Widevine architecture found: {arch}', arch=self._arch())
-            ok_dialog(localize(30004), localize(30007))  # Widevine not available on this architecture
+            ok_dialog(localize(30004), localize(30007, arch=self._arch()))  # Widevine not available on this architecture
             return False
 
         if system_os() not in config.WIDEVINE_SUPPORTED_OS:

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "Wegen lizenzrechtlicher Reglementierungen muss die [B]Widevine CDM[/B] Bibliothek aus einem Chrome OS Image extrahiert werden. Dafür sind mindestens [B]{diskspace}[/B] freier Festplattenspeicher notwendig. Soll der Vorgang fortgesetzt werden?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "Die [B]Widevine CDM[/B] Bibliothek ist leider für diese System-Architektur nicht verfügbar."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "Die [B]Widevine CDM[/B] Bibliothek ist leider für diese System-Architektur ([B]{arch}[/B]) nicht verfügbar."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Kodi in der Version {version}[/B] oder höher wird benötigt, um [B]Widevine CDM[/B] geschützte Inhalte wiederzugeben."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Das genutzte Betriebssystem ([B]{0}[/B]) wird aktuell nicht von der [B]Widevine CDM[/B] Bibliothek unterstützt."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Das genutzte Betriebssystem ([B]{os}[/B]) wird aktuell nicht von der [B]Widevine CDM[/B] Bibliothek unterstützt."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "Λόγω ενοχλητικών προβλημάτων, το [B]Widevine CDM[/B] πρέπει να εξαχθεί από μία εικόνα επαναφοράς του Chrome OS. Για τον λόγο αυτόν απαιτείται τουλάχιστον [B]{diskspace}[/B] ελεύθερου χώρου. Επιθυμείτε να συνεχίσετε;"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "Το [B]Widevine CDM[/B] δυστυχώς δεν είναι διαθέσιμο για την αρχιτεκτονική του συστήματος σας."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "Το [B]Widevine CDM[/B] δυστυχώς δεν είναι διαθέσιμο για την αρχιτεκτονική του συστήματος σας ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Kodi {version}[/B] ή μεταγενέστερο απαιτείται για την αναπαραγωγή μέσω [B]Widevine CDM[/B] γι' αυτό το περιεχόμενο."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Το παρόν λειτουργικό σύστημα ([B]{0}[/B]) δεν υποστηρίζεται από το [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Το παρόν λειτουργικό σύστημα ([B]{os}[/B]) δεν υποστηρίζεται από το [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -34,7 +34,7 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr ""
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
 msgstr ""
 
 msgctxt "#30008"
@@ -50,7 +50,7 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr ""
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
 msgstr ""
 
 msgctxt "#30012"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "En raison des droits de distribution, [B]Widevine CDM[/B] doit être extrait d'une image de récupération de Chrome OS. Ce processus nécessite au moins [B]{diskspace}[/B] d'espace disque disponible. Souhaitez-vous continuer ?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "[B]Widevine CDM[/B] n'est malheureusement pas disponible sur cette architecture système"
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "[B]Widevine CDM[/B] n'est malheureusement pas disponible sur cette architecture système ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Kodi {version}[/B] ou supérieur est nécessaire pour la lecture du contenu avec [B]Widevine CDM[/B]."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Ce système d'exploitation ([B]{0}[/B]) n'est pas supporté par [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Ce système d'exploitation ([B]{os}[/B]) n'est pas supporté par [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "Zbog prava distribucije, [B]Widevine CDM[/B] treba izvući iz preslike za oporavak Chrome OS-a. Za ovaj je postupak potrebno najmanje [B]{diskspace}[/B] slobodnog prostora na disku. Želite li nastaviti?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "[B]Widevine CDM[/B] nažalost nije dostupan za ovu arhitekturu sustava."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "[B]Widevine CDM[/B] nažalost nije dostupan za ovu arhitekturu sustava ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "Potreban je [B]Kodi {verzija}[/B] ili noviji za reprodukciju sadržaja preko [B]Widevine CDM[/B]."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B] ne podržava ovaj operativni sustav ([B]{0}[/B]) ."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "[B]Widevine CDM[/B] ne podržava ovaj operativni sustav ([B]{os}[/B]) ."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
@@ -83,7 +83,7 @@ msgstr "Nemate dovoljno slobodnog prostora na disku da biste instalirali [B]Wide
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "[B]Widevine CDM[/B] za ARM uređaje ne podržava ovaj operativni sustav ([B]{0}[/B]) ."
+msgstr "[B]Widevine CDM[/B] za ARM uređaje ne podržava ovaj operativni sustav ([B]{os}[/B]) ."
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "A terjesztési jogok miatt a [B]Widevine CDM-et[/B]a Chrome OS helyreállítási képből kell kivonni. Ehhez legalább [B]{diskspace}[/B] szabad lemezterületre van szükség. Folytatni akarja?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "[B]A Widevine CDM[/B] sajnos nem érhető el ezen a rendszer architektúrán."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "[B]A Widevine CDM[/B] sajnos nem érhető el ezen a rendszer architektúrán ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Kodi {version}[/B] vagy magasabb verzió kell a [B]Widevine CDM[/B] tartalom lejátszásához."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Ezt az operációs rendszert ([B]{0}[/B]) nem támogstja a [B]Widevine CDM[/B]"
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Ezt az operációs rendszert ([B]{os}[/B]) nem támogstja a [B]Widevine CDM[/B]"
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "A causa di diritti di distribuzione, [B]Widevine CDM[/B] deve essere estratto dall'immagine di recovery di Chrome OS. Questo processo richiede almeno [B]{diskspace}[/B] di spazio libero. Vuoi continuare?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "[B]Widevine CDM[/B] sfortunatamente non e' disponibile per l'architettura del tuo processore."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "[B]Widevine CDM[/B] sfortunatamente non e' disponibile per l'architettura del tuo processore ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "E' richiesto [B]Kodi {version}[/B] o superiore per riprodurre contenuti con [B]Widevine CDM[/B]."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Il tuo sistema operativo ([B]{0}[/B]) non e' supportato da [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Il tuo sistema operativo ([B]{os}[/B]) non e' supportato da [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "配給権の理由で、[B]Widevine CDM[/B]をChrome OSのリカバリイメージから抽出しなければなりません。このため[B]{diskspace}[/B]以上の空き容量が必要です。続きますか。"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "このシステムにて使用可能な[B]Widevine CDM[/B]はありません。"
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "このシステムにて使用可能な[B]Widevine CDM[/B]はありません。([B]{arch}[/B])"
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Widevine CDM[/B]コンテンツを再生するため、[B]Kodi {version}[/B]以後が必要です。"
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]はこのシステム([B]{0}[/B])に対応しません。"
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "[B]Widevine CDM[/B]はこのシステム([B]{os}[/B])に対応しません。"
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
@@ -83,7 +83,7 @@ msgstr "[B]Widevine CDM[/B]をインストールする充分はスペースが�
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "[B]Widevine CDM[/B]は、このOS([B]{0}[/B])を対応しません。"
+msgstr "[B]Widevine CDM[/B]は、このOS([B]{os}[/B])を対応しません。"
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "배포권리 때문에, [B]Widevine CDM[/B]을 크롬OS리커버리 이미지로부터 뽑아내야하며, 최소 [B]{diskspace}[/B]의 여유공간이 필요합니다. 계속 하시렵니까?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "이 시스템에 알맞은 [B]Widevine CDM[/B]이 없습니다."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "이 시스템에 알맞은 [B]Widevine CDM[/B]이 없습니다 ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Widevine CDM[/B] 컨텐츠를 재생하려면 [B]Kodi {version}[/B] 혹은 그 이상이 필요합니다."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{0}[/B])을(를) 지원하지 않습니다."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{os}[/B])을(를) 지원하지 않습니다."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
@@ -83,7 +83,7 @@ msgstr "[B]Widevine CDM[/B]을 설치할 만한 공간이 없으니, [B]{diskspa
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{0}[/B])을(를) 지원하지 않습니다."
+msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{os}[/B])을(를) 지원하지 않습니다."
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "Wegens distributierechten moet [B]Widevine CDM[/B] worden uitgepakt uit een recovery-image van Chrome OS. Voor dit process is minimaal [B]{diskspace}[/B] vrije schijfruimte nodig. Wil je doorgaan?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "[B]Widevine CDM[/B] is helaas niet beschikbaar voor deze syteemarchitectuur."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "[B]Widevine CDM[/B] is helaas niet beschikbaar voor deze syteemarchitectuur ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Kodi {version}[/B] of hoger is nodig om met [B]Widevine CDM[/B] beschermde video's af te spelen."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Dit besturingssysteem ([B]{0}[/B] wordt niet ondersteund door [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Dit besturingssysteem ([B]{os}[/B] wordt niet ondersteund door [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "Из-за проблем с распространением, [B]Widevine CDM[/B] необходимо извлечь из образа восстановления Chrome OS. Для этого процесса требуется минимум [B]{diskspace}[/B] свободного дискового пространства. Вы хотите продолжить?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "К сожалению, [B]Widevine CDM[/B] не доступен для текущей архитектуры системы."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "К сожалению, [B]Widevine CDM[/B] не доступен для текущей архитектуры системы ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "Требуется [B]Kodi {version}[/B] или выше для воспроизведения контента с помощью [B]Widevine CDM[/B]."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Эта операционная система ([B]{0}[/B]) не поддерживается [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Эта операционная система ([B]{os}[/B]) не поддерживается [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -34,8 +34,8 @@ msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from 
 msgstr "På grund av distributionsrättigheter måste [B]Widevine CDM[/B] extraheras från en Chrome OS-återställningsavbild. Denna process kräver minst [B]{diskspace}[/B] ledigt diskutrymme. Vill du fortsätta?"
 
 msgctxt "#30007"
-msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
-msgstr "[B]Widevine CDM[/B] är tyvärr inte tillgängligt på den här systemarkitekturen."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
+msgstr "[B]Widevine CDM[/B] är tyvärr inte tillgängligt på den här systemarkitekturen ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,8 +50,8 @@ msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] conte
 msgstr "[B]Kodi {version}[/B eller högre krävs för att spela upp [B]Widevine CDM[/B]-skyddat material."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Detta operativsystemet ([B]{0}[/B]) stöds inte av [B]Widevine CDM[/B]."
+msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Detta operativsystemet ([B]{os}[/B]) stöds inte av [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."


### PR DESCRIPTION
This displays the unsupported architecture in the dialog to the user.

It also fixes an incorrect reference to {os}.

This relates to #268 