### PR TITLE
Add a 5 second timeout for chunk download

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -369,7 +369,7 @@ class Helper:
         filename = url.split('/')[-1]
 
         try:
-            req = urlopen(url)
+            req = urlopen(url, timeout=5)
             log('Response code: {code}', code=req.getcode())
             if 400 <= req.getcode() < 600:
                 raise HTTPError('HTTP %s Error for url: %s' % (req.getcode(), url), response=req)


### PR DESCRIPTION
On bad connections,  a single chunk download can fail, causing the entire download to fail. Adding this timeout fixed it on my bad connection.
Fixes #274