### PR TITLE
Add option to calculate checksum in _http_download()

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -398,7 +398,8 @@ class Helper:
             elif hash_alg == 'md5':
                 calc_checksum = md5()
             else:
-                raise ValueError('Invalid hash algorithm specified: {}'.format(hash_alg))
+                log('Invalid hash algorithm specified: {}'.format(hash_alg))
+                checksum = None
 
         req = self._http_request(url)
         if req is None:

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -389,7 +389,7 @@ class Helper:
         # log('Response: {response}', response=content)
         return content.decode()
 
-    def _http_download(self, url, message=None, checksum=None, hash_alg='sha1'):
+    def _http_download(self, url, message=None, checksum=None, hash_alg='sha1', dl_size=None):
         """Makes HTTP request and displays a progress dialog on download."""
         if checksum:
             from hashlib import sha1, md5
@@ -435,6 +435,12 @@ class Helper:
         if checksum and not calc_checksum.hexdigest() == checksum:
             log('Download failed, checksums do not match!')
             return False
+
+        from xbmcvfs import Stat
+        if dl_size and not Stat(self._download_path).st_size() == dl_size:
+            log('Download failed, filesize does not match!')
+            return False
+
         progress.close()
         req.close()
         return True
@@ -701,7 +707,7 @@ class Helper:
                 return False
 
             url = arm_device['url']
-            downloaded = self._http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1')  # Downloading the recovery image
+            downloaded = self._http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1', dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
             if downloaded:
                 from threading import Thread
                 from xbmc import sleep

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -29,6 +29,10 @@ def Stat(path):
             """The xbmcvfs stat class st_mtime method"""
             return self._stat.st_mtime
 
+        def st_size(self):
+            """The xbmcvfs stat class st_size method"""
+            return self._stat.st_size
+
     return stat(path)
 
 


### PR DESCRIPTION
I tested the following script on an RPi3 using Raspbian:

```python
from hashlib import md5, sha1
from datetime import datetime

def check(alg):
    with open("chromeos_12607.82.0_nyan-kitty_recovery_stable-channel_kitty-mp-v2.bin.zip", "r") as f:
        starttime = datetime.now()
        print("{} started at {}".format(alg, starttime))
        if alg == 'md5':
            checksum = md5()
            should_be = '245b4eb00dba6752b0038ba447440799'
        elif alg == 'sha1':
            checksum = sha1()
            should_be = '86afee8b24784947cfecbc49a42fe58538a003b5'
        else:
            print('Specify sha1 or md5')
            return

#        chunktime = datetime.now()
        while True:
            chunk = f.read(32*1024)
            if not chunk:
                break
            checksum.update(chunk)
#            print("next chunk calculated after {}, total {}".format(datetime.now() - chunktime, datetime.now() - starttime))
#            chunktime = datetime.now()
        h = checksum.hexdigest()
        print("Calculated {} with hexdigest {} at {} after {}".format(checksum, h, datetime.now(), datetime.now() - starttime))
        if h == should_be:
            print('Checksum correct')
        else:
            print('CHECKSUM INCORRECT!')

check('md5')
check('sha1')
check('md5')
check('sha1')
```

The results were 3.7s for md5 and 4.7s for sha1 (both times). I think that's fast enough to be negligible compared to download time.
So this PR adds the option to calculate the checksum to `_http_download()` and use it in `_install_widevine_arm()`.

This relates to #265.