### PR TITLE
Use explicit relative imports instead of sys.path.append

### DIFF
--- a/default.py
+++ b/default.py
@@ -3,18 +3,6 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import sys
-import os.path
-from xbmc import translatePath
-from xbmcaddon import Addon
-
-
-def to_unicode(text, encoding='utf-8'):
-    ''' Force text to unicode '''
-    return text.decode(encoding) if isinstance(text, bytes) else text
-
-
-# NOTE: This is required so our RunScript interface can import our own inputstreamhelper package
-sys.path.append(os.path.join(to_unicode(translatePath(Addon().getAddonInfo('path'))), 'lib'))
-from inputstreamhelper.api import run  # noqa: E402
+from lib.inputstreamhelper.api import run
 
 run(sys.argv)

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import os
-from inputstreamhelper import config
+from . import config
 from .kodiutils import (addon_profile, addon_version, browsesingle, get_proxies, get_setting, get_setting_bool,
                         get_setting_float, get_setting_int, jsonrpc, kodi_to_ascii, kodi_version, localize, log, notification,
                         ok_dialog, progress_dialog, select_dialog, set_setting, set_setting_bool, textviewer,

--- a/lib/inputstreamhelper/api.py
+++ b/lib/inputstreamhelper/api.py
@@ -3,7 +3,7 @@
 """This is the actual InputStream Helper API script"""
 
 from __future__ import absolute_import, division, unicode_literals
-from inputstreamhelper import Helper
+from . import Helper
 from .kodiutils import ADDON, log
 
 


### PR DESCRIPTION
Many thanks to @enen92 for figuring this solution out.
Meanwhile I tested this on the following systems and it just works fine!
- Kodi 19.0-ALPHA1 Git:20200226-cde760b94e on Windows x64
- Kodi 18.6 on Linux x64 and Windows x64
- LibreELEC 9.2.0
- LibreELEC 8.2.5