### PR TITLE
Support exporting Kodi 19 Matrix compatible zip package

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.4" provider-name="emilsvennesson, dagwieers, mediaminister">
   <requires>
     <!--py3 compliant-->
-    <!--<import addon="xbmc.python" version="2.25.0" target="3.0.0"/>-->
+    <!--<import addon="xbmc.python" version="2.25.0" targetversion="3.0.0"/>-->
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
   </requires>


### PR DESCRIPTION
This adds support for automatically building a Kodi 19 Matrix compatible zip package with `make`.

This includes:
- automatically change the Python ABI version in addon.xml (change to **3.0.0** for Matrix)
- automatically change the addon version using local version identifier ([PEP-440](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers)) (add **+matrix.1** to current version for Matrix)

How to build:
```
cd script.module.inputstreamhelper
make multizip
```