### PR TITLE
Automate Github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  build:
+    name: Release script.module.inputstreamhelper
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build zip files
+        run: |
+          sudo apt-get install libxml2-utils
+          make multizip release=1
+      - name: Get Krypton filename
+        id: get-krypton-filename
+        run: |
+          echo ::set-output name=krypton-filename::$(cd ..;ls script.module.inputstreamhelper*.zip | grep -v '+matrix.' | head -1)
+      - name: Get Matrix filename
+        id: get-matrix-filename
+        run: |
+          echo ::set-output name=matrix-filename::$(cd ..;ls script.module.inputstreamhelper*+matrix.*.zip | head -1)
+      - name: Get body
+        id: get-body
+        run: |
+          description=$(sed '1,/^## Releases$/d;/## v[0-9\.]* ([0-9-]*)/d;/^$/,$d' README.md)
+          echo $description
+          description="${description//'%'/'%25'}"
+          description="${description//$'\n'/'%0A'}"
+          description="${description//$'\r'/'%0D'}" 
+          echo ::set-output name=body::$description
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.get-body.outputs.body }}
+          draft: false
+          prerelease: false
+      - name: Upload Krypton/Leia zip
+        id: upload-krypton-zip 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: ${{ steps.get-krypton-filename.outputs.krypton-filename }}
+          asset_path: ../${{ steps.get-krypton-filename.outputs.krypton-filename }}
+          asset_content_type: application/zip
+      - name: Upload Matrix zip
+        id: upload-matrix-zip 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: ${{ steps.get-matrix-filename.outputs.matrix-filename }}
+          asset_path: ../${{ steps.get-matrix-filename.outputs.matrix-filename }}
+          asset_content_type: application/zip

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,12 @@ git_branch = $(shell git rev-parse --abbrev-ref HEAD)
 git_hash = $(shell git rev-parse --short HEAD)
 matrix = $(findstring $(shell xmllint --xpath 'string(/addon/requires/import[@addon="xbmc.python"]/@version)' addon.xml), $(word 1,$(KODI_PYTHON_ABIS)))
 
-zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
+ifdef release
+	zip_name = $(name)-$(version).zip
+else
+	zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
+endif
+
 include_files = addon.xml changelog.txt default.py LICENSE.txt README.md lib/ resources/
 include_paths = $(patsubst %,$(name)/%,$(include_files))
 exclude_files = \*.new \*.orig \*.pyc \*.pyo


### PR DESCRIPTION
This automates future Github releases when pushing a version tag:
- reads latest changelog from README.md and adds this to the Github release
- automatic generation of zip packages for Kodi Krypton/Leia and Matrix