### PR TITLE
Simplify userspace detection on ARM64

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -142,6 +142,13 @@ class Helper:
             ok_dialog(localize(30004), localize(30007, arch=arch()))  # Widevine not available on this architecture
             return False
 
+        if arch() == 'arm64' and system_os() != 'Android':
+            import struct
+            if struct.calcsize('P') * 8 == 64:
+                log('Unsupported 64-bit userspace found. User needs 32-bit userspace on {arch}', arch=arch())
+                ok_dialog(localize(30004), localize(30039))  # Widevine not available on ARM64
+                return False
+
         if system_os() not in config.WIDEVINE_SUPPORTED_OS:
             log(4, 'Unsupported Widevine OS found: {os}', os=system_os())
             ok_dialog(localize(30004), localize(30011, os=system_os()))  # Operating system not supported by Widevine

--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -238,13 +238,7 @@ def arch():
 
     from platform import architecture, machine
     sys_arch = machine()
-    if sys_arch == 'aarch64':
-        import struct
-        if struct.calcsize('P') * 8 == 32:
-            # Detected 64-bit kernel in 32-bit userspace, use 32-bit arm widevine
-            sys_arch = 'arm'
-
-    elif sys_arch == 'AMD64':
+    if sys_arch == 'AMD64':
         sys_arch_bit = architecture()[0]
         if sys_arch_bit == '32bit':
             sys_arch = 'x86'  # else, sys_arch = AMD64

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -141,12 +141,6 @@ def missing_widevine_libs():
             log(0, 'There are no missing Widevine libraries! :-)')
             return None
 
-    if arch() == 'arm64':
-        import struct
-        if struct.calcsize('P') * 8 == 64:
-            log(4, 'ARM64 ldd check failed. User needs 32-bit userspace.')
-            ok_dialog(localize(30004), localize(30039))  # Widevine not available on ARM64
-
     log(4, 'Failed to check for missing Widevine libraries.')
     return None
 


### PR DESCRIPTION
This fixes https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/294

It is confirmed this works to detect  64-bit userspace on ARM64.

Before merging, this should be tested more, especially on Android.