### PR TITLE
Don't fail on untranslated strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
       run: python -m tox -q -e flake8,py
     - name: Run pylint
       run: python -m pylint lib/ tests/
-    - name: Compare translations
+    - name: Compare translation strings
       run: make check-translations
+    - name: Check for untranslated strings
+      run: make check-untranslated
+      continue-on-error: true
     # Python 2.7 and Python 3.5 are no longer supported by proxy.py
     - name: Start proxy server, when supported
       run: python -m proxy --hostname 127.0.0.1 --log-level DEBUG &

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ check-pylint:
 check-translations:
 	@echo -e "$(white)=$(blue) Starting language test$(reset)"
 	@-$(foreach lang,$(languages), \
+		msgcmp --use-untranslated resources/language/resource.language.$(lang)/strings.po resources/language/resource.language.en_gb/strings.po; \
+	)
+
+check-untranslated:
+	@echo -e "$(white)=$(blue) Starting language test$(reset)"
+	@-$(foreach lang,$(languages), \
 		msgcmp resources/language/resource.language.$(lang)/strings.po resources/language/resource.language.en_gb/strings.po; \
 	)
 


### PR DESCRIPTION
Currently CI would fail on untranslated strings, but during development
this is to be expected. So we check now for both, but don't fail for
untranslated strings.