### PR TITLE
Improve settings behavior for all supported Kodi versions

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,12 +7,12 @@
         <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
         <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
-        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)" visible="!system.platform.android"/>
-        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="!system.platform.android"/>
-        <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="!system.platform.android"/>
-        <setting type="sep" visible="!system.platform.android"/>
-        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
-        <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
-        <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="System.HasAddon(inputstream.adaptive)" visible="!system.platform.android"/>
+        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting type="sep" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
     </category>
 </settings>


### PR DESCRIPTION
This pull request Improves settings behavior:
- hides Widevine settings on Kodi 17 Krypton
- fixes disabling Widevine settings when InputStream Adaptive is disabled or missing on Kodi 19