### PR TITLE
Add cached property functions

### DIFF
--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -19,7 +19,7 @@ class progress_dialog(DialogProgress, object):  # pylint: disable=invalid-name,u
         """Create and show a progress dialog"""
         if kodi_version_major() < 19:
             lines = message.split('\n', 2)
-            line1, line2, line3 = (lines + [None] * (3-len(lines)))
+            line1, line2, line3 = (lines + [None] * (3 - len(lines)))
             return super(progress_dialog, self).create(heading, line1=line1, line2=line2, line3=line3)
         return super(progress_dialog, self).create(heading, message=message)
 
@@ -27,7 +27,7 @@ class progress_dialog(DialogProgress, object):  # pylint: disable=invalid-name,u
         """Update the progress dialog"""
         if kodi_version_major() < 19:
             lines = message.split('\n', 2)
-            line1, line2, line3 = (lines + [None] * (3-len(lines)))
+            line1, line2, line3 = (lines + [None] * (3 - len(lines)))
             return super(progress_dialog, self).update(percent, line1=line1, line2=line2, line3=line3)
         return super(progress_dialog, self).update(percent, message=message)
 

--- a/tests/test_ishelper_android_arm.py
+++ b/tests/test_ishelper_android_arm.py
@@ -18,6 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 class AndroidARMTests(unittest.TestCase):
 
     def test_check_inputstream_mpd(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Android'
         platform.machine = lambda: 'arm'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
@@ -26,6 +27,7 @@ class AndroidARMTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_hls_again(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Android'
         platform.machine = lambda: 'armv7'
         is_helper = inputstreamhelper.Helper('hls', drm='com.widevine.alpha')
@@ -33,6 +35,7 @@ class AndroidARMTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_rtmp(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Android'
         platform.machine = lambda: 'armv8'
         is_helper = inputstreamhelper.Helper('rtmp')
@@ -40,6 +43,7 @@ class AndroidARMTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_disabled(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Android'
         platform.machine = lambda: 'arm'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')

--- a/tests/test_ishelper_linux_arm.py
+++ b/tests/test_ishelper_linux_arm.py
@@ -18,6 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 class LinuxARMTests(unittest.TestCase):
 
     def test_check_inputstream_mpd(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'arm'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
@@ -26,6 +27,7 @@ class LinuxARMTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_hls_again(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'armv7'
         is_helper = inputstreamhelper.Helper('hls', drm='com.widevine.alpha')
@@ -33,6 +35,7 @@ class LinuxARMTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_rtmp(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'armv8'
         is_helper = inputstreamhelper.Helper('rtmp')
@@ -40,6 +43,7 @@ class LinuxARMTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_disabled(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'arm'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')

--- a/tests/test_ishelper_linux_x64.py
+++ b/tests/test_ishelper_linux_x64.py
@@ -18,6 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 class LinuxX64Tests(unittest.TestCase):
 
     def test_check_inputstream_mpd(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
@@ -26,6 +27,7 @@ class LinuxX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_hls_again(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'AMD64'
         platform.architecture = lambda: ['64bit', '']
@@ -34,6 +36,7 @@ class LinuxX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_rtmp(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('rtmp')
@@ -41,6 +44,7 @@ class LinuxX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_disabled(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')

--- a/tests/test_ishelper_macos_x64.py
+++ b/tests/test_ishelper_macos_x64.py
@@ -18,6 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 class DarwinX64Tests(unittest.TestCase):
 
     def test_check_inputstream_mpd(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Darwin'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
@@ -26,6 +27,7 @@ class DarwinX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_hls_again(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Darwin'
         platform.machine = lambda: 'AMD64'
         platform.architecture = lambda: ['64bit', '']
@@ -34,6 +36,7 @@ class DarwinX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_rtmp(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Darwin'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('rtmp')
@@ -41,6 +44,7 @@ class DarwinX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_disabled(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Darwin'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')

--- a/tests/test_ishelper_windows_x64.py
+++ b/tests/test_ishelper_windows_x64.py
@@ -18,6 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 class WindowsX64Tests(unittest.TestCase):
 
     def test_check_inputstream_mpd(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Windows'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
@@ -26,6 +27,7 @@ class WindowsX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_hls_again(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Windows'
         platform.machine = lambda: 'AMD64'
         platform.architecture = lambda: ['64bit', '']
@@ -34,6 +36,7 @@ class WindowsX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_rtmp(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Windows'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('rtmp')
@@ -41,6 +44,7 @@ class WindowsX64Tests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_disabled(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Windows'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -29,6 +29,7 @@ class LinuxProxyTests(unittest.TestCase):
         xbmc.settings['network.usehttpproxy'] = False
 
     def test_check_inputstream_mpd(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
@@ -37,6 +38,7 @@ class LinuxProxyTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_hls_again(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'AMD64'
         platform.architecture = lambda: ['64bit', '']
@@ -45,6 +47,7 @@ class LinuxProxyTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_rtmp(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('rtmp')
@@ -52,6 +55,7 @@ class LinuxProxyTests(unittest.TestCase):
         self.assertTrue(is_installed, True)
 
     def test_check_inputstream_disabled(self):
+        inputstreamhelper.utils.delete_cached([inputstreamhelper.system_os, inputstreamhelper.arch])
         inputstreamhelper.system_os = lambda: 'Linux'
         platform.machine = lambda: 'x86_64'
         is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')


### PR DESCRIPTION
After https://github.com/emilsvennesson/script.module.inputstreamhelper/commit/830cfb566133e8e925722bdafe623b5b65ecc420 was merged, unit tests didn't fully execute anymore because they used cached properties for arch() and system_os() information.

This pull request adds get/set/delete wrapper functions for the cached properties and deletes the cached properties when executing unit tests.