### PR TITLE
Delete arch.cached property in unit tests

### DIFF
--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -19,7 +19,7 @@ class progress_dialog(DialogProgress, object):  # pylint: disable=invalid-name,u
         """Create and show a progress dialog"""
         if kodi_version_major() < 19:
             lines = message.split('\n', 2)
-            line1, line2, line3 = (lines + [None] * (3-len(lines)))
+            line1, line2, line3 = (lines + [None] * (3 - len(lines)))
             return super(progress_dialog, self).create(heading, line1=line1, line2=line2, line3=line3)
         return super(progress_dialog, self).create(heading, message=message)
 
@@ -27,7 +27,7 @@ class progress_dialog(DialogProgress, object):  # pylint: disable=invalid-name,u
         """Update the progress dialog"""
         if kodi_version_major() < 19:
             lines = message.split('\n', 2)
-            line1, line2, line3 = (lines + [None] * (3-len(lines)))
+            line1, line2, line3 = (lines + [None] * (3 - len(lines)))
             return super(progress_dialog, self).update(percent, line1=line1, line2=line2, line3=line3)
         return super(progress_dialog, self).update(percent, message=message)
 

--- a/tests/test_ishelper_android_arm.py
+++ b/tests/test_ishelper_android_arm.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 import platform
 import inputstreamhelper
+from test_utils import delete_cached
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -16,6 +17,9 @@ xbmcvfs = __import__('xbmcvfs')
 
 
 class AndroidARMTests(unittest.TestCase):
+
+    def setUp(self):
+        delete_cached()
 
     def test_check_inputstream_mpd(self):
         inputstreamhelper.system_os = lambda: 'Android'

--- a/tests/test_ishelper_linux_arm.py
+++ b/tests/test_ishelper_linux_arm.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 import platform
 import inputstreamhelper
+from test_utils import delete_cached
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -16,6 +17,9 @@ xbmcvfs = __import__('xbmcvfs')
 
 
 class LinuxARMTests(unittest.TestCase):
+
+    def setUp(self):
+        delete_cached()
 
     def test_check_inputstream_mpd(self):
         inputstreamhelper.system_os = lambda: 'Linux'

--- a/tests/test_ishelper_linux_x64.py
+++ b/tests/test_ishelper_linux_x64.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 import platform
 import inputstreamhelper
+from test_utils import delete_cached
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -16,6 +17,9 @@ xbmcvfs = __import__('xbmcvfs')
 
 
 class LinuxX64Tests(unittest.TestCase):
+
+    def setUp(self):
+        delete_cached()
 
     def test_check_inputstream_mpd(self):
         inputstreamhelper.system_os = lambda: 'Linux'

--- a/tests/test_ishelper_macos_x64.py
+++ b/tests/test_ishelper_macos_x64.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 import platform
 import inputstreamhelper
+from test_utils import delete_cached
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -16,6 +17,9 @@ xbmcvfs = __import__('xbmcvfs')
 
 
 class DarwinX64Tests(unittest.TestCase):
+
+    def setUp(self):
+        delete_cached()
 
     def test_check_inputstream_mpd(self):
         inputstreamhelper.system_os = lambda: 'Darwin'

--- a/tests/test_ishelper_windows_x64.py
+++ b/tests/test_ishelper_windows_x64.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 import platform
 import inputstreamhelper
+from test_utils import delete_cached
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -16,6 +17,9 @@ xbmcvfs = __import__('xbmcvfs')
 
 
 class WindowsX64Tests(unittest.TestCase):
+
+    def setUp(self):
+        delete_cached()
 
     def test_check_inputstream_mpd(self):
         inputstreamhelper.system_os = lambda: 'Windows'

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,6 +9,7 @@ import sys
 import unittest
 import platform
 import inputstreamhelper
+from test_utils import delete_cached
 
 xbmc = __import__('xbmc')
 xbmcaddon = __import__('xbmcaddon')
@@ -24,6 +25,7 @@ class LinuxProxyTests(unittest.TestCase):
         xbmc.settings['network.httpproxytype'] = 0
         xbmc.settings['network.httpproxyserver'] = '127.0.0.1'
         xbmc.settings['network.httpproxyport'] = '8899'
+        delete_cached()
 
     def tearDown(self):
         xbmc.settings['network.usehttpproxy'] = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
+"""Implements various helper functions"""
+
+from __future__ import absolute_import, division, unicode_literals
+import inputstreamhelper
+
+
+def delete_cached():
+    """Delete cached property from one or more objects"""
+    if hasattr(inputstreamhelper.arch, 'cached'):
+        del inputstreamhelper.arch.cached


### PR DESCRIPTION
After https://github.com/emilsvennesson/script.module.inputstreamhelper/commit/830cfb566133e8e925722bdafe623b5b65ecc420 was merged, unit tests didn't fully execute anymore because they used the cached property in `arch()`.

Deleting the cached property when executing unit tests solves this bug.