### PR TITLE
Use temp path with unicode chars for testing

### DIFF
--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -7,7 +7,7 @@ import os
 
 from . import config
 from .kodiutils import copy, delete, exists, get_setting, localize, log, mkdirs, ok_dialog, progress_dialog, set_setting, stat_file, translate_path
-
+from .unicodes import from_unicode
 
 def temp_path():
     """Return temporary path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp"""
@@ -176,7 +176,8 @@ def store(name, val=None):
 
 def diskspace():
     """Return the free disk space available (in bytes) in temp_path."""
-    statvfs = os.statvfs(temp_path())
+    # Python 2.7: os.statvfs() not working well with unicode paths https://bugs.python.org/issue18695
+    statvfs = os.statvfs(from_unicode(temp_path()))
     return statvfs.f_frsize * statvfs.f_bavail
 
 

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -250,8 +250,8 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
 
 def extract_widevine_from_img(backup_path):
     """Extract the Widevine CDM binary from the mounted Chrome OS image"""
-    for root, _, files in os.walk(str(mnt_path())):
-        if str('libwidevinecdm.so') not in files:
+    for root, _, files in os.walk(mnt_path()):
+        if 'libwidevinecdm.so' not in files:
             continue
         cdm_path = os.path.join(root, 'libwidevinecdm.so')
         log(0, 'Found libwidevinecdm.so in {path}', path=cdm_path)

--- a/tests/userdata/addon_settings.json
+++ b/tests/userdata/addon_settings.json
@@ -6,7 +6,7 @@
     "script.module.inputstreamhelper": {
         "disabled": "false", 
         "last_update": "", 
-        "temp_path": "special://masterprofile/addon_data/script.module.inputstreamhelper", 
+        "temp_path": "special://masterprofile/addon_data/script.module.inputstreamhelper/ũnícødētèst", 
         "update_frequency": "31", 
         "version": ""
     }

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -12,6 +12,7 @@ import json
 import time
 import weakref
 from xbmcextra import ADDON_ID, GLOBAL_SETTINGS as settings, LANGUAGE
+from inputstreamhelper.unicodes import to_unicode
 
 LOGLEVELS = ['Debug', 'Info', 'Notice', 'Warning', 'Error', 'Severe', 'Fatal', 'None']
 LOGDEBUG = 0
@@ -269,7 +270,7 @@ def log(msg, level=0):
         color1 = '\033[33;1m'
     elif level == 0:
         color2 = '\033[30;1m'
-    print('{color1}{name}: {color2}{msg}\033[39;0m'.format(name=name, color1=color1, color2=color2, msg=str(msg)))
+    print('{color1}{name}: {color2}{msg}\033[39;0m'.format(name=name, color1=color1, color2=color2, msg=to_unicode(msg)))
 
 
 def setContent(self, content):
@@ -287,9 +288,9 @@ def translatePath(path):
     if path.startswith('special://home'):
         return path.replace('special://home', os.path.join(os.getcwd(), 'tests/'))
     if path.startswith('special://masterprofile'):
-        return path.replace('special://masterprofile', os.path.join(os.getcwd(), 'tests/userdata/'))
+        return path.replace('special://masterprofile', os.path.join(os.getcwd(), 'tests/userdata'))
     if path.startswith('special://profile'):
-        return path.replace('special://profile', os.path.join(os.getcwd(), 'tests/userdata/'))
+        return path.replace('special://profile', os.path.join(os.getcwd(), 'tests/userdata'))
     if path.startswith('special://userdata'):
-        return path.replace('special://userdata', os.path.join(os.getcwd(), 'tests/userdata/'))
+        return path.replace('special://userdata', os.path.join(os.getcwd(), 'tests/userdata'))
     return path

--- a/tests/xbmcaddon.py
+++ b/tests/xbmcaddon.py
@@ -6,7 +6,6 @@
 # pylint: disable=invalid-name
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-from xbmc import getLocalizedString
 from xbmcextra import ADDON_ID, ADDON_INFO, addon_settings
 
 
@@ -28,6 +27,7 @@ class Addon:
     @staticmethod
     def getLocalizedString(msgctxt):
         """A working implementation for the xbmcaddon Addon class getLocalizedString() method"""
+        from xbmc import getLocalizedString
         return getLocalizedString(msgctxt)
 
     def getSetting(self, key):


### PR DESCRIPTION
In the past we never tested temp paths containing unicode characters and unicode bugs were left undetected. We could only fix these bugs after a user created an issue.

This pull request fixes a couple of unicode bugs and adds unicode chars to the tests temp_path in addon_settings.json.