### PR TITLE
Closes #333

### DIFF
--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -250,7 +250,7 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
 
 def extract_widevine_from_img(backup_path):
     """Extract the Widevine CDM binary from the mounted Chrome OS image"""
-    for root, _, files in os.walk(mnt_path()):
+    for root, _, files in os.walk(str(mnt_path())):
         if 'libwidevinecdm.so' not in files:
             continue
         cdm_path = os.path.join(root, 'libwidevinecdm.so')


### PR DESCRIPTION
without str() I was getting an error "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 29: ordinal not in range(128)", adding str() fixes this error.