### PR TITLE
Bugfix: fix os.walk error from wrong input type

### DIFF
--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -250,7 +250,7 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
 
 def extract_widevine_from_img(backup_path):
     """Extract the Widevine CDM binary from the mounted Chrome OS image"""
-    for root, _, files in os.walk(mnt_path()):
+    for root, _, files in os.walk(str(mnt_path())):
         if 'libwidevinecdm.so' not in files:
             continue
         cdm_path = os.path.join(root, 'libwidevinecdm.so')


### PR DESCRIPTION
I was getting an error when installing widewine, this fixed it. I saw there is a pull request #334 for #333 regarding the behaviour of mnt_path().  This pull request fixes the issue without touching the mnt_path(), which I imagine may be used in other places, and imo should be compatible with any eventual changes to mnt_path() behaviour, as the underlying behavior of os.walk() cannot be changed easily. See the commit message below for explanation:

Fix errors in os.walk by casting the input path into bytestring. Without it, os.walk may throw an uncought exception. Here is an explanation from someone who seems to know what Python2 is about:

If you pass a unicode string into os.walk(), then os.walk starts getting unicode back from os.listdir() and tries to keep it as ASCII (hence 'ascii' decode error). When it hits a unicode only special character which str() can't translate, it throws the exception.
The solution is to force the starting path you pass to os.walk to be a regular string - i.e. os.walk(str(somepath)). This means os.listdir returns regular byte-like strings and everything works the way it should. 
From: https://stackoverflow.com/questions/21772271/unicodedecodeerror-when-performing-os-walk