### PR TITLE
Track real progress of unzip in install_widevine_arm

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Entpacke das Image..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Dies kann einige Minuten in Anspruch nehmen. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Dies kann einige Minuten in Anspruch nehmen."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Keine Backups gefunden!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Wählen Sie ein Backup zum Wiederherstellen aus."
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Εξαγωγή εικόνας..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Αυτό μπορεί να διαρκέσει μερικά λεπτά. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Αυτό μπορεί να διαρκέσει μερικά λεπτά."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Δεν βρεθήκανε αντίγραφα ασφαλείας!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Επιλέξτε ένα αντίγραφο ασφαλείας για επαναφορά"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -190,7 +190,7 @@ msgid "Uncompressing image..."
 msgstr ""
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
 msgstr ""
 
 msgctxt "#30047"
@@ -235,6 +235,10 @@ msgstr ""
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
 

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Descomprimiendo la imagen..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Esto puede tomar varios minutos. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Esto puede tomar varios minutos."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "¡No se encontraron copias de seguridad!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Seleccione una copia de seguridad a restaurar"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Décompression de l'image ..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Cela peut pendre quelques minutes. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Cela peut pendre quelques minutes."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Aucune sauvegarde trouvée!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Choisissez une sauvegarde à restaurer"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Raspakiranje preslike u tijeku…"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Ovo bi moglo potrajati nekoliko minuta. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Ovo bi moglo potrajati nekoliko minuta."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Nisu pronađene sigurnosne kopije!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Odaberite sigurnosnu kopiju za vraćanje"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Lemezkép kitömörítése"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Ez néhány percig eltarthat. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Ez néhány percig eltarthat."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Nem található mentés fájl!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Válassz mentés fájlt a visszaállításhoz"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Sto estraendo l'immagine"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Potrebbero volerci alcuni minuti. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Potrebbero volerci alcuni minuti."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Backup non trovato!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Scegli un backup da ripristinare"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.ja_JP/strings.po
+++ b/resources/language/resource.language.ja_JP/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "イメージを解凍中。。。"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "少し時間掛かります。({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "少し時間掛かります。"
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "バックアップがありませんよ!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "バックアップを選んでください"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.ko_KR/strings.po
+++ b/resources/language/resource.language.ko_KR/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "이미지를 풀어 내는 중..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "시간이 조금 걸립니다. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "시간이 조금 걸립니다."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "저런! 백업이 없어요!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "복구할 백업을 고르시지요"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "De recovery-image wordt uitgepakt..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Dit kan enkele minuten duren. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Dit kan enkele minuten duren."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Geen backups gevonden!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Kies een back-up om te herstellen"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -191,8 +191,8 @@ msgid "Uncompressing image..."
 msgstr "Se decompresează imaginea..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Acest proces poate dura câteva minute. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Acest proces poate dura câteva minute."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -237,6 +237,10 @@ msgstr "Nu au fost găsite copii de siguranță!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Alegeți o copie de siguranță pentru a fi restabilită"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Распаковка образа..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Это может занять несколько минут. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Это может занять несколько минут."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Резервные копии не найдены!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Выберите резервную копию для восстановления"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Packar upp avbilden..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Detta kan ta flera minuter. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Detta kan ta flera minuter."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Hittade inga säkerhetskopior!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Välj säkerhetskopia att återställa"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG


### PR DESCRIPTION
This changes the way the ChromeOS image is extracted and tracks the progress. It most probably fixes #325 .

With this change, the `unzip()` function isn't used anywhere at all, but I wasn't sure, if it should be removed.