### PR TITLE
Access the zipped Chrome OS image directly

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,9 +1,10 @@
 [MESSAGES CONTROL]
 disable=
     bad-option-value,
-    duplicate-code,
-    import-outside-toplevel,
-    line-too-long,
+    duplicate-code,  # Integration tests tend to test similar things
+    fixme,  # Allow FIXMEs in code is a useful practice
+    import-outside-toplevel,  # Done on purpose to reduce overhead at startup
+    line-too-long,  # Flake8 is used for testing line-length
     old-style-class,
     too-many-arguments,
     too-many-branches,

--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -121,10 +121,14 @@ def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=Non
             )
 
     if checksum and not calc_checksum.hexdigest() == checksum:
+        progress.close()
+        req.close()
         log(4, 'Download failed, checksums do not match!')
         return False
 
     if dl_size and not stat_file(download_path).st_size() == dl_size:
+        progress.close()
+        req.close()
         log(4, 'Download failed, filesize does not match!')
         return False
 

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -4,13 +4,14 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import os
+import json
 from time import time
-from struct import unpack, calcsize
 
 from .. import config
 from ..kodiutils import browsesingle, copy, exists, localize, log, mkdir, ok_dialog, open_file, progress_dialog, yesno_dialog
 from ..utils import cmd_exists, diskspace, http_download, http_get, run_cmd, sizeof_fmt, store, system_os, temp_path, update_temp_path
 from ..unicodes import compat_path, to_unicode
+from .arm_chromeos import ChromeOSImage
 
 
 def mnt_path():
@@ -20,52 +21,6 @@ def mnt_path():
         mkdir(mount_path)
 
     return mount_path
-
-
-def gpt_header(bytestream):
-    """Returns the needed parts of the GPT header, can be easily expanded if necessary"""
-    header_fmt = '<8s4sII4x4Q16sQ3I'
-    header_size = calcsize(header_fmt)
-
-    # GPT Header entries: signature, revision, header_size, header_crc32, (reserved 4x skipped,) current_lba, backup_lba,
-    #                     first_usable_lba, last_usable_lba, disk_guid, start_lba_part_entries, num_part_entries,
-    #                     size_part_entry, crc32_part_entries
-    _, _, _, _, _, _, _, _, _, start_lba_part_entries, num_part_entries, size_part_entry, _ = unpack(header_fmt, bytestream.read(header_size))
-    bytestream.read(config.CHROMEOS_BLOCK_SIZE - header_size)  # go to LBA 2
-
-    return (start_lba_part_entries, num_part_entries, size_part_entry)
-
-
-def chromeos_offset(bytestream):
-    """Calculate the Chrome OS losetup start offset"""
-    lba_size = config.CHROMEOS_BLOCK_SIZE
-    part_format = '<16s16sQQQ72s'
-    bytestream.read(lba_size)  # skip MBR
-    entries_start, entries_num, entry_size = gpt_header(bytestream)
-
-    if not entries_start == 2:
-        if entries_start < 2:
-            log(4, 'GPT partition entries start too early')
-            return 0
-        bytestream.read((entries_start - 2) * lba_size)
-
-    if not calcsize(part_format) == entry_size:
-        log(4, 'Partition table entries are not 128 bytes long')
-        return 0
-
-    for index in range(1, entries_num+1):  # pylint: disable=unused-variable
-        #Entry: type_guid, unique_guid, first_lba, last_lba, attr_flags, part_name
-        _, _, first_lba, _, _, part_name = unpack(part_format, bytestream.read(entry_size))
-        part_name = part_name.decode('utf-16').strip('\x00')
-        if part_name == 'ROOT-A':
-            offset = first_lba * lba_size
-            break
-
-    if not offset:
-        log(4, 'Failed to calculate losetup offset.')
-        return 0
-
-    return offset
 
 
 def check_loop():
@@ -95,8 +50,7 @@ def set_loop_dev():
 
 def losetup(bin_path):
     """Setup Chrome OS loop device."""
-    with open(bin_path, 'rb') as cos_image:
-        cos_offset = str(chromeos_offset(cos_image))
+    cos_offset = str(ChromeOSImage(bin_path).chromeos_offset())
 
     cmd = ['losetup', '-o', cos_offset, store('loop_dev'), bin_path]
     output = run_cmd(cmd, sudo=True)
@@ -184,15 +138,72 @@ def chromeos_config():
     return devices
 
 
-def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
+def install_widevine_arm(backup_path):
     """Installs Widevine CDM on ARM-based architectures."""
+    devices = chromeos_config()
+    arm_device = select_best_chromeos_image(devices)
+    if arm_device is None:
+        log(4, 'We could not find an ARM device in the Chrome OS recovery.conf')
+        ok_dialog(localize(30004), localize(30005))
+        return False
+    # Estimated required disk space: takes into account an extra 20 MiB buffer
+    required_diskspace = 20971520 + int(arm_device['zipfilesize'])
+    if yesno_dialog(localize(30001),  # Due to distributing issues, this takes a long time
+                    localize(30006, diskspace=sizeof_fmt(required_diskspace))):
+        if system_os() != 'Linux':
+            ok_dialog(localize(30004), localize(30019, os=system_os()))
+            return False
+
+        while required_diskspace >= diskspace():
+            if yesno_dialog(localize(30004), localize(30055)):  # Not enough space, alternative path?
+                update_temp_path(browsesingle(3, localize(30909), 'files'))  # Temporary path
+                continue
+
+            ok_dialog(localize(30004),  # Not enough free disk space
+                      localize(30018, diskspace=sizeof_fmt(required_diskspace)))
+            return False
+
+        url = arm_device['url']
+        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1', dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
+        if downloaded:
+            progress = progress_dialog()
+            progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
+
+            extracted = ChromeOSImage(store('download_path')).extract_file(
+                filename=config.WIDEVINE_CDM_FILENAME[system_os()],
+                extract_path=os.path.join(backup_path, arm_device['version']),
+                progress=progress)
+
+            if not extracted:
+                log(3, 'Directly extracting widevine from the zip failed, using legacy method.')
+                if yesno_dialog(heading=localize(30004),
+                                message='{line1}\n{line2}\n{line3}'.format(
+                                    line1=localize(30016),
+                                    line2=localize(30830, url=config.ISSUE_URL),
+                                    line3=localize(30059))
+                               ):
+                    return install_wv_arm_legacy(backup_path)
+                return False
+
+
+            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
+            with open_file(json_file, 'w') as config_file:
+                config_file.write(json.dumps(devices, indent=4))
+
+            return (progress, arm_device['version'])
+
+    return False
+
+
+def install_wv_arm_legacy(backup_path):
+    """Legacy method to install Widevine CDM on ARM-based architectures."""
     root_cmds = ['mount', 'umount', 'losetup', 'modprobe']
     devices = chromeos_config()
     arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
         log(4, 'We could not find an ARM device in the Chrome OS recovery.conf')
         ok_dialog(localize(30004), localize(30005))
-        return ''
+        return False
     # Estimated required disk space: takes into account an extra 20 MiB buffer
     required_diskspace = 20971520 + int(arm_device['zipfilesize']) + int(arm_device['filesize'])
     if yesno_dialog(localize(30001),  # Due to distributing issues, this takes a long time
@@ -228,55 +239,52 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
             return False
 
         url = arm_device['url']
-        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1', dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
-        if downloaded:
-            progress = progress_dialog()
-            progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
-            bin_filename = url.split('/')[-1].replace('.zip', '')
-            bin_path = compat_path(os.path.join(temp_path(), bin_filename))
-            starttime = time()
+        progress = progress_dialog()
+        progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
+        bin_filename = url.split('/')[-1].replace('.zip', '')
+        bin_path = compat_path(os.path.join(temp_path(), bin_filename))
+        starttime = time()
 
-            progress.update(
-                0,
-                message='{line1}\n{line2}\n{line3}'.format(
-                    line1=localize(30045),  # Uncompressing image
-                    line2=localize(30058, mins=0, secs=0),  # Time remaining
-                    line3=localize(30047))  # Please do not interrupt this process
-            )
+        progress.update(
+            0,
+            message='{line1}\n{line2}\n{line3}'.format(
+                line1=localize(30045),  # Uncompressing image
+                line2=localize(30058, mins=0, secs=0),  # Time remaining
+                line3=localize(30047))  # Please do not interrupt this process
+        )
 
-            from zipfile import ZipFile
+        from zipfile import ZipFile
 
-            with ZipFile(compat_path(store('download_path'))) as zip_obj:
-                bin_size = zip_obj.getinfo(bin_filename).file_size
-                chunksize = 1024**2
+        with ZipFile(compat_path(store('download_path'))) as zip_obj:
+            bin_size = zip_obj.getinfo(bin_filename).file_size
+            chunksize = 1024**2
 
-                with zip_obj.open(bin_filename) as member:
-                    with open(bin_path, 'wb') as bin_file:
-                        bytes_to_read = bin_size
-                        while bytes_to_read > 0:
-                            chunk = member.read(chunksize)
-                            bytes_to_read -= chunksize
-                            bin_file.write(chunk)
-                            percent = 100 * (1 - bytes_to_read / bin_size) - 5
-                            time_left = int(bytes_to_read * (time() - starttime) / (bin_size - bytes_to_read))
-                            progress.update(
-                                int(percent),
-                                message='{line1}\n{line2}\n{line3}'.format(
-                                    line1=localize(30045),  # Uncompressing image
-                                    line2=localize(30058, mins=time_left // 60, secs=time_left % 60),  # Time remaining
-                                    line3=localize(30047))  # Please do not interrupt this process
-                            )
+            with zip_obj.open(bin_filename) as member:
+                with open(bin_path, 'wb') as bin_file:
+                    bytes_to_read = bin_size
+                    while bytes_to_read > 0:
+                        chunk = member.read(chunksize)
+                        bytes_to_read -= chunksize
+                        bin_file.write(chunk)
+                        percent = 100 * (1 - bytes_to_read / bin_size) - 5
+                        time_left = int(bytes_to_read * (time() - starttime) / (bin_size - bytes_to_read))
+                        progress.update(
+                            int(percent),
+                            message='{line1}\n{line2}\n{line3}'.format(
+                                line1=localize(30045),  # Uncompressing image
+                                line2=localize(30058, mins=time_left // 60, secs=time_left % 60),  # Time remaining
+                                line3=localize(30047))  # Please do not interrupt this process
+                        )
 
-            if check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
-                import json
-                progress.update(96, message=localize(30048))  # Extracting Widevine CDM
-                extract_widevine_from_img(os.path.join(backup_path, arm_device['version']))
-                json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
-                with open_file(json_file, 'w') as config_file:
-                    config_file.write(json.dumps(devices, indent=4))
+        if check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
+            progress.update(96, message=localize(30048))  # Extracting Widevine CDM
+            extract_widevine_from_img(os.path.join(backup_path, arm_device['version']))
+            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
+            with open_file(json_file, 'w') as config_file:
+                config_file.write(json.dumps(devices, indent=4))
 
-                return (progress, arm_device['version'])
-            progress.close()
+            return (progress, arm_device['version'])
+        progress.close()
 
     return False
 

--- a/lib/inputstreamhelper/widevine/arm_chromeos.py
+++ b/lib/inputstreamhelper/widevine/arm_chromeos.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+# MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
+"""Implements a class with methods related to the Chrome OS image"""
+
+from __future__ import absolute_import, division
+import os
+from struct import calcsize, unpack
+from zipfile import ZipFile
+from io import UnsupportedOperation
+
+from ..kodiutils import exists, localize, log, mkdirs
+from .. import config
+
+
+class ChromeOSImage:
+    """
+    The main class handling a Chrome OS image
+
+    Information related to ext2 is sourced from here: https://www.nongnu.org/ext2-doc/ext2.html
+    """
+
+
+    def __init__(self, imgpath):
+        """Prepares the image"""
+        self.imgpath = imgpath
+        self.get_bstream()
+        self.part_offset = self.chromeos_offset()
+        self.sb_dict = self.superblock()
+        self.blk_groups = self.block_groups()
+        self.progress = None
+
+
+    def gpt_header(self):
+        """Returns the needed parts of the GPT header, can be easily expanded if necessary"""
+        header_fmt = '<8s4sII4x4Q16sQ3I'
+        header_size = calcsize(header_fmt)
+        lba_size = config.CHROMEOS_BLOCK_SIZE
+        self.seek_stream(lba_size)
+
+        # GPT Header entries: signature, revision, header_size, header_crc32, (reserved 4x skipped,) current_lba, backup_lba,
+        #                     first_usable_lba, last_usable_lba, disk_guid, start_lba_part_entries, num_part_entries,
+        #                     size_part_entry, crc32_part_entries
+        _, _, _, _, _, _, _, _, _, start_lba_part_entries, num_part_entries, size_part_entry, _ = unpack(header_fmt, self.read_stream(header_size))
+
+        return (start_lba_part_entries, num_part_entries, size_part_entry)
+
+
+    def chromeos_offset(self):
+        """Calculate the Chrome OS losetup start offset"""
+        part_format = '<16s16sQQQ72s'
+        entries_start, entries_num, entry_size = self.gpt_header()
+        lba_size = config.CHROMEOS_BLOCK_SIZE
+        self.seek_stream(entries_start * lba_size)
+
+        if not calcsize(part_format) == entry_size:
+            log(4, 'Partition table entries are not 128 bytes long')
+            return 0
+
+        for index in range(1, entries_num+1):  # pylint: disable=unused-variable
+            #Entry: type_guid, unique_guid, first_lba, last_lba, attr_flags, part_name
+            _, _, first_lba, _, _, part_name = unpack(part_format, self.read_stream(entry_size))
+            part_name = part_name.decode('utf-16').strip('\x00')
+            if part_name == 'ROOT-A':
+                offset = first_lba * lba_size
+                break
+
+        if not offset:
+            log(4, 'Failed to calculate losetup offset.')
+            return 0
+
+        return offset
+
+
+    def extract_file(self, filename, extract_path, progress):
+        """Extracts the file from the image"""
+        self.progress = progress
+        bin_filename = filename.encode('ascii')
+        chunksize = 4*1024**2
+        percent = 5
+        count = 0
+        self.progress.update(percent, localize(30060))
+        chunk1 = self.read_stream(chunksize)
+        while True:
+            chunk2 = self.read_stream(chunksize)
+            if not chunk2:
+                log(4, 'File {filename} not found in the ChromeOS image', filename=filename)
+                return False
+
+            chunk = chunk1 + chunk2
+            if bin_filename in chunk:
+                break
+            chunk1 = chunk2
+            if percent < 30 and count == 8:
+                count = 0
+                percent += 1
+                self.progress.update(percent)
+            else:
+                count += 1
+
+        self.progress.update(30, localize(30048))
+
+        i_index_pos = chunk.index(bin_filename)-8
+        dir_dict = self.dir_entry(chunk[i_index_pos:i_index_pos+len(filename)+8])
+
+        blk_group_num = (dir_dict['inode']-1) // self.sb_dict['s_inodes_per_group']
+        blk_group = self.blk_groups[blk_group_num]
+        i_index_in_group = (dir_dict['inode']-1) % self.sb_dict['s_inodes_per_group']
+
+        inode_pos = self.part_offset + self.blocksize*blk_group['bg_inode_table'] + self.sb_dict['s_inode_size']*i_index_in_group
+        inode_dict, _ = self.inode_table(inode_pos)
+
+        return self.write_file(inode_dict, os.path.join(extract_path, filename))
+
+
+    def superblock(self):
+        """Get relevant info from the superblock, assert it's an ext2 fs"""
+        names = ('s_inodes_count', 's_blocks_count', 's_r_blocks_count', 's_free_blocks_count', 's_free_inodes_count', 's_first_data_block',
+                 's_log_block_size', 's_log_frag_size', 's_blocks_per_group', 's_frags_per_group', 's_inodes_per_group', 's_mtime', 's_wtime',
+                 's_mnt_count', 's_max_mnt_count', 's_magic', 's_state', 's_errors', 's_minor_rev_level', 's_lastcheck', 's_checkinterval',
+                 's_creator_os', 's_rev_level', 's_def_resuid', 's_def_resgid', 's_first_ino', 's_inode_size', 's_block_group_nr',
+                 's_feature_compat', 's_feature_incompat', 's_feature_ro_compat', 's_uuid', 's_volume_name', 's_last_mounted',
+                 's_algorithm_usage_bitmap', 's_prealloc_block', 's_prealloc_dir_blocks'
+                )
+        fmt = '<13I6H4I2HI2H3I16s16s64sI2B818x'
+        fmt_len = calcsize(fmt)
+
+        self.seek_stream(self.part_offset + 1024)  # superblock starts after 1024 byte
+        pack = self.read_stream(fmt_len)
+        sb_dict = dict(zip(names, unpack(fmt, pack)))
+
+        sb_dict['s_magic'] = hex(sb_dict['s_magic'])
+        assert sb_dict['s_magic'] == '0xef53'  # identifies this as ext2 fs
+
+        block_groups_count1 = sb_dict['s_blocks_count']/sb_dict['s_blocks_per_group']
+        block_groups_count1 = int(block_groups_count1) if float(int(block_groups_count1)) == block_groups_count1 else int(block_groups_count1)+1
+        block_groups_count2 = sb_dict['s_inodes_count']/sb_dict['s_inodes_per_group']
+        block_groups_count2 = int(block_groups_count2) if float(int(block_groups_count2)) == block_groups_count2 else int(block_groups_count2)+1
+        assert block_groups_count1 == block_groups_count2
+        sb_dict['block_groups_count'] = block_groups_count1
+
+        self.blocksize = 1024 << sb_dict['s_log_block_size']
+
+        return sb_dict
+
+
+    def block_group(self):
+        """Get info about a block group"""
+        names = ('bg_block_bitmap', 'bg_inode_bitmap', 'bg_inode_table', 'bg_free_blocks_count', 'bg_free_inodes_count', 'bg_used_dirs_count', 'bg_pad')
+        fmt = '<3I4H12x'
+        fmt_len = calcsize(fmt)
+
+        pack = self.read_stream(fmt_len)
+        blk = unpack(fmt, pack)
+
+        blk_dict = dict(zip(names, blk))
+
+        return blk_dict
+
+
+    def block_groups(self):
+        """Get info about all block groups"""
+        if self.blocksize == 1024:
+            self.seek_stream(self.part_offset + 2 * self.blocksize)
+        else:
+            self.seek_stream(self.part_offset + self.blocksize)
+
+        blk_groups = []
+        for i in range(self.sb_dict['block_groups_count']):  # pylint: disable=unused-variable
+            blk_group = self.block_group()
+            blk_groups.append(blk_group)
+
+        return blk_groups
+
+
+    def inode_table(self, inode_pos):
+        """Reads and returns an inode table and inode size"""
+        names = ('i_mode', 'i_uid', 'i_size', 'i_atime', 'i_ctime', 'i_mtime', 'i_dtime', 'i_gid', 'i_links_count', 'i_blocks', 'i_flags',
+                 'i_osd1', 'i_block0', 'i_block1', 'i_block2', 'i_block3', 'i_block4', 'i_block5', 'i_block6', 'i_block7', 'i_block8',
+                 'i_block9', 'i_block10', 'i_block11', 'i_blocki', 'i_blockii', 'i_blockiii', 'i_generation', 'i_file_acl', 'i_dir_acl', 'i_faddr')
+        fmt = '<2Hi4I2H3I15I4I12x'
+        fmt_len = calcsize(fmt)
+        inode_size = self.sb_dict['s_inode_size']
+
+        self.seek_stream(inode_pos)
+        pack = self.read_stream(fmt_len)
+        inode = unpack(fmt, pack)
+
+        inode_dict = dict(zip(names, inode))
+        inode_dict['i_mode'] = hex(inode_dict['i_mode'])
+
+        blocks = inode_dict['i_size']/self.blocksize
+        inode_dict['blocks'] = int(blocks) if float(int(blocks)) == blocks else int(blocks)+1
+
+        self.read_stream(inode_size-fmt_len)
+        return inode_dict, inode_size
+
+
+    @staticmethod
+    def dir_entry(chunk):
+        """Returns the directory entry found in chunk"""
+        dir_names = ('inode', 'rec_len', 'name_len', 'file_type', 'name')
+        dir_fmt = '<IHBB' + str(len(chunk)-8) + 's'
+
+        dir_dict = dict(zip(dir_names, unpack(dir_fmt, chunk)))
+
+        return dir_dict
+
+
+    def iblock_ids(self, blk_id, ids_to_read):
+        """Reads the block indices/IDs from an indirect block"""
+        seek_pos = self.part_offset + self.blocksize*blk_id
+        self.seek_stream(seek_pos)
+        fmt = '<' + str(int(self.blocksize/4)) + 'I'
+        ids = list(unpack(fmt, self.read_stream(self.blocksize)))
+        ids_to_read -= len(ids)
+
+        return ids, ids_to_read
+
+
+    def iiblock_ids(self, blk_id, ids_to_read):
+        """Reads the block indices/IDs from a doubly-indirect block"""
+        seek_pos = self.part_offset + self.blocksize*blk_id
+        self.seek_stream(seek_pos)
+        fmt = '<' + str(int(self.blocksize/4)) + 'I'
+        iids = unpack(fmt, self.read_stream(self.blocksize))
+
+        ids = []
+        for iid in iids:
+            if ids_to_read <= 0:
+                break
+            ind_block_ids, ids_to_read = self.iblock_ids(iid, ids_to_read)
+            ids += ind_block_ids
+
+        return ids, ids_to_read
+
+
+    def seek_stream(self, seek_pos):
+        """Move position of bstream to seek_pos"""
+        try:
+            self.bstream[0].seek(seek_pos)
+            self.bstream[1] = seek_pos
+            return
+
+        except UnsupportedOperation:
+            chunksize = 4*1024**2
+
+            if seek_pos >= self.bstream[1]:
+                while seek_pos - self.bstream[1] > chunksize:
+                    self.read_stream(chunksize)
+                self.read_stream(seek_pos - self.bstream[1])
+                return
+
+            self.bstream[0].close()
+            self.bstream[1] = 0
+            self.get_bstream()
+
+            while seek_pos - self.bstream[1] > chunksize:
+                self.read_stream(chunksize)
+            self.read_stream(seek_pos - self.bstream[1])
+
+            return
+
+
+    def read_stream(self, num_of_bytes):
+        """Read and return a chunk of the bytestream"""
+        self.bstream[1] += num_of_bytes
+
+        return self.bstream[0].read(num_of_bytes)
+
+
+    def get_block_ids(self, inode_dict):
+        """Get all block indices/IDs of an inode"""
+        ids_to_read = inode_dict['blocks']
+        block_ids = [inode_dict['i_block' + str(i)] for i in range(12)]
+        ids_to_read -= 12
+
+        if not inode_dict['i_blocki'] == 0:
+            iblocks, ids_to_read = self.iblock_ids(inode_dict['i_blocki'], ids_to_read)
+            block_ids += iblocks
+        if not inode_dict['i_blockii'] == 0:
+            iiblocks, ids_to_read = self.iiblock_ids(inode_dict['i_blockii'], ids_to_read)
+            block_ids += iiblocks
+
+        return block_ids[:inode_dict['blocks']]
+
+
+    def read_file(self, block_ids):
+        """Read blocks specified by IDs into a dict"""
+        block_dict = {}
+        for block_id in block_ids:
+            percent = int(35 + 60 * block_ids.index(block_id) / len(block_ids))
+            self.progress.update(percent, localize(30061))
+            seek_pos = self.part_offset + self.blocksize*block_id
+            self.seek_stream(seek_pos)
+            block_dict[block_id] = self.read_stream(self.blocksize)
+
+        return block_dict
+
+
+    @staticmethod
+    def write_file_chunk(opened_file, chunk, bytes_to_write):
+        """Writes bytes to file in chunks"""
+        if len(chunk) > bytes_to_write:
+            opened_file.write(chunk[:bytes_to_write])
+            return 0
+
+        opened_file.write(chunk)
+        return bytes_to_write - len(chunk)
+
+
+    def write_file(self, inode_dict, filepath):
+        """Writes file specified by its inode to filepath"""
+        bytes_to_write = inode_dict['i_size']
+        block_ids = self.get_block_ids(inode_dict)
+
+        block_ids_sorted = block_ids[:]
+        block_ids_sorted.sort()
+        block_dict = self.read_file(block_ids_sorted)
+
+        if not exists(os.path.dirname(filepath)):
+            mkdirs(os.path.dirname(filepath))
+
+
+        with open(filepath, 'wb') as opened_file:
+            for block_id in block_ids:
+                bytes_to_write = self.write_file_chunk(opened_file, block_dict[block_id], bytes_to_write)
+                if bytes_to_write == 0:
+                    return True
+
+        return False
+
+
+    def get_bstream(self):
+        """Get a bytestream of the image"""
+        if self.imgpath.endswith('.zip'):
+            bstream = ZipFile(self.imgpath, 'r').open(os.path.basename(self.imgpath).strip('.zip'), 'r')
+        else:
+            bstream = open(self.imgpath, 'rb')
+
+        self.bstream = [bstream, 0]

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -241,6 +241,18 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Searching the Chrome OS image for the Widevine CDM"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Reading the file..."
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"


### PR DESCRIPTION
Okay, as promised in https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/319#issuecomment-623191660, here is another PR about installing Widevine on ARM.

It accesses the zipped image directly, and extracts the lib from it. On an RPi3 this takes around half the time it takes to extract the whole image and (obviously) only uses about one third of disk space.

I tested this on an RPi3 and it seems to work. The reason it's still a Draft PR is because the progress dialog needs improvement and there are some messages not yet localized (mainly in the progress dialog).
But you're welcome to test it already, the only changes I have planned are the two points mentioned above and they shouldn't affect the actual code.

This is based on #327 and (imho) supersedes #319 . It resolves #72 .