### PR TITLE
Fix linting warnings and unicode compatibility

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -426,7 +426,10 @@ class Helper:
             text += ' - ' + localize(30821) + '\n'
         else:
             from datetime import datetime
-            wv_updated = datetime.fromtimestamp(get_setting_float('last_update', 0.0)).strftime("%Y-%m-%d %H:%M") if get_setting_float('last_update', 0.0) else 'Never'
+            if get_setting_float('last_update', 0.0):
+                wv_updated = datetime.fromtimestamp(get_setting_float('last_update', 0.0)).strftime("%Y-%m-%d %H:%M")
+            else:
+                wv_updated = 'Never'
             text += ' - ' + localize(30822, version=self._get_lib_version(widevinecdm_path()), date=wv_updated) + '\n'
             text += ' - ' + localize(30823, path=ia_cdm_path()) + '\n'
 

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -80,7 +80,8 @@ def browsesingle(type, heading, shares='', mask='', useThumbs=False, treatAsFold
     from xbmcgui import Dialog
     if not heading:
         heading = ADDON.getAddonInfo('name')
-    return to_unicode(Dialog().browseSingle(type=type, heading=heading, shares=shares, mask=mask, useThumbs=useThumbs, treatAsFolder=treatAsFolder, defaultt=defaultt))
+    return to_unicode(Dialog().browseSingle(type=type, heading=heading, shares=shares, mask=mask, useThumbs=useThumbs,
+                                            treatAsFolder=treatAsFolder, defaultt=defaultt))
 
 
 def notification(heading='', message='', icon='info', time=4000):

--- a/lib/inputstreamhelper/unicodes.py
+++ b/lib/inputstreamhelper/unicodes.py
@@ -22,6 +22,7 @@ def from_unicode(text, encoding='utf-8', errors='strict'):
 def compat_path(path, encoding='utf-8', errors='strict'):
     """Convert unicode path to bytestring if needed"""
     import sys
-    if sys.version_info.major == 2 and isinstance(path, unicode) and not sys.platform.startswith('win'):  # noqa: F821; pylint: disable=undefined-variable,useless-suppression
+    if (sys.version_info.major == 2 and isinstance(path, unicode)  # noqa: F821; pylint: disable=undefined-variable,useless-suppression
+            and not sys.platform.startswith('win')):
         return path.encode(encoding, errors)
     return path

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -164,7 +164,8 @@ def install_widevine_arm(backup_path):
             return False
 
         url = arm_device['url']
-        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1', dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
+        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
+                                   dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
         if downloaded:
             progress = progress_dialog()
             progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
@@ -180,11 +181,9 @@ def install_widevine_arm(backup_path):
                                 message='{line1}\n{line2}\n{line3}'.format(
                                     line1=localize(30016),
                                     line2=localize(30830, url=config.ISSUE_URL),
-                                    line3=localize(30059))
-                               ):
+                                    line3=localize(30059))):
                     return install_wv_arm_legacy(backup_path)
                 return False
-
 
             json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
             with open_file(json_file, 'w') as config_file:


### PR DESCRIPTION
This fixes some code style warnings:
- Fix E501 line too long
- Fix E226 missing whitespace around arithmetic operator
- Fix E303 too many blank lines
- Fix E124 closing bracket does not match visual indentation
- Fix E265 block comment should start with '# '

And also adds compatibility for unicode chars in paths:
- use `compat_path` when opening a full path with `open()` or `ZipFile()`