### PR TITLE
Improvements to http dl and request

### DIFF
--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -5,9 +5,17 @@
 from __future__ import absolute_import, division, unicode_literals
 import os
 from time import time
+from socket import timeout
+from ssl import SSLError
+
+try:  # Python 3
+    from urllib.error import HTTPError, URLError
+    from urllib.request import Request, urlopen
+except ImportError:  # Python 2
+    from urllib2 import HTTPError, Request, URLError, urlopen
 
 from . import config
-from .kodiutils import bg_progress_dialog, copy, delete, exists, get_setting, localize, log, mkdirs, ok_dialog, progress_dialog, set_setting, stat_file, translate_path
+from .kodiutils import bg_progress_dialog, copy, delete, exists, get_setting, localize, log, mkdirs, progress_dialog, set_setting, stat_file, translate_path, yesno_dialog
 from .unicodes import compat_path, from_unicode, to_unicode
 
 
@@ -30,26 +38,25 @@ def update_temp_path(new_temp_path):
         move(old_temp_path, temp_path())
 
 
-def _http_request(url, timeout=10):
+def _http_request(url, headers=None, time_out=10):
     """Perform an HTTP request and return request"""
-
-    try:  # Python 3
-        from urllib.error import HTTPError
-        from urllib.request import urlopen
-    except ImportError:  # Python 2
-        from urllib2 import HTTPError, urlopen
-
     log(0, 'Request URL: {url}', url=url)
-    filename = url.split('/')[-1]
 
     try:
-        req = urlopen(url, timeout=timeout)
+        if headers:
+            request = Request(url, headers=headers)
+        else:
+            request = Request(url)
+        req = urlopen(request, timeout=time_out)
         log(0, 'Response code: {code}', code=req.getcode())
         if 400 <= req.getcode() < 600:
             raise HTTPError('HTTP %s Error for url: %s' % (req.getcode(), url), response=req)
-    except HTTPError:
-        ok_dialog(localize(30004), localize(30013, filename=filename))  # Failed to retrieve file
+    except (HTTPError, URLError) as err:
+        log(2, 'Download failed with error {}'.format(err))
+        if yesno_dialog(localize(30004), '{line1}\n{line2}'.format(line1=localize(30063), line2=localize(30065))):  # Internet down, try again?
+            return _http_request(url, headers, time_out)
         return None
+
     return req
 
 
@@ -101,21 +108,32 @@ def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=Non
     chunk_size = 32 * 1024
     with open(compat_path(download_path), 'wb') as image:
         size = 0
-        while True:
-            chunk = req.read(chunk_size)
-            if not chunk:
-                break
+        while size < total_length:
+            try:
+                chunk = req.read(chunk_size)
+            except (timeout, SSLError):
+                req.close()
+                if not yesno_dialog(localize(30004), '{line1}\n{line2}'.format(line1=localize(30064), line2=localize(30065))):  # Could not finish dl. Try again?
+                    progress.close()
+                    return False
+
+                headers = {'Range': 'bytes={}-{}'.format(size, total_length)}
+                req = _http_request(url, headers=headers)
+                if req is None:
+                    return None
+                continue
+
             image.write(chunk)
             if checksum:
                 calc_checksum.update(chunk)
             size += len(chunk)
-            percent = int(size * 100 / total_length)
+            percent = int(round(size * 100 / total_length))
             if not background and progress.iscanceled():
                 progress.close()
                 req.close()
                 return False
             if time() - starttime > 5:
-                time_left = int((total_length - size) * (time() - starttime) / size)
+                time_left = int(round((total_length - size) * (time() - starttime) / size))
                 prog_message = '{line1}\n{line2}'.format(
                     line1=message,
                     line2=localize(30058, mins=time_left // 60, secs=time_left % 60))  # Time remaining

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -257,6 +257,18 @@ msgctxt "#30062"
 msgid "Widevine CDM found, analyzing..."
 msgstr ""
 
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr ""
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr ""
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"


### PR DESCRIPTION
This includes:
* Report free disk space if after download the filesizes do not match (as discussed https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/281#issuecomment-614294737)
* Retry downloading if it fails, base on code from @mediaminister here https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/305#issuecomment-627511506

This resolves #281 and fixes #305, but there are two points which I'd like to discuss before merging:

* `total_length` is a float, I think it should be int?
* What should be done if the `dl_size` (the zipfilesize of the Chrome OS image extracted from recovery.conf) does not match `total_length`?