### PR TITLE
Wait before creating progress dialog

### DIFF
--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -19,6 +19,7 @@ class progress_dialog(DialogProgress, object):  # pylint: disable=invalid-name,u
     def create(self, heading, message=''):  # pylint: disable=arguments-differ
         """Create and show a progress dialog"""
         if kodi_version_major() < 19:
+            xbmc.sleep(400)  # Wait for previous dialog to close, else inherits lines
             lines = message.split('\n', 2)
             line1, line2, line3 = (lines + [None] * (3 - len(lines)))
             return super(progress_dialog, self).create(heading, line1=line1, line2=line2, line3=line3)


### PR DESCRIPTION
If a progress dialog is created right after calling `close()` on another, it might happen that it isn't actually closed, so the content (especially line2 and line3) would be inherited. That's why the "Time remaining: 0:00" stayed there on ARM.

On Kodi 19 this issue doesn't exist, because line2 and line3 don't exist there, but there is still a warning in the debug log that a dialog is already running.