### PR TITLE
Changes to last_update

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -227,7 +227,6 @@ class Helper:
 
         if self.install_and_finish(*result):
             from time import time
-            set_setting('last_update', time())
             set_setting('last_check', time())
             return True
 
@@ -242,6 +241,7 @@ class Helper:
             log(0, 'Removed Widevine CDM at {path}', path=widevinecdm)
             delete(widevinecdm)
             notification(localize(30037), localize(30052))  # Success! Widevine successfully removed.
+            set_setting('last_modified', '0.0')
             return True
         notification(localize(30004), localize(30053))  # Error. Widevine CDM not found.
         return False
@@ -432,8 +432,8 @@ class Helper:
             text += ' - ' + localize(30821) + '\n'
         else:
             from time import localtime, strftime
-            if get_setting_float('last_update', 0.0):
-                wv_updated = strftime('%Y-%m-%d %H:%M', localtime(get_setting_float('last_update', 0.0)))
+            if get_setting_float('last_modified', 0.0):
+                wv_updated = strftime('%Y-%m-%d %H:%M', localtime(get_setting_float('last_modified', 0.0)))
             else:
                 wv_updated = 'Never'
             text += ' - ' + localize(30822, version=self._get_lib_version(widevinecdm_path()), date=wv_updated) + '\n'

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -229,6 +229,7 @@ class Helper:
             from datetime import datetime
             from time import mktime
             set_setting('last_update', mktime(datetime.utcnow().timetuple()))
+            set_setting('last_check', mktime(datetime.utcnow().timetuple()))
             return True
 
         ok_dialog(localize(30004), localize(30005))  # An error occurred
@@ -266,11 +267,11 @@ class Helper:
         """Prompts user to upgrade Widevine CDM when a newer version is available."""
         from datetime import datetime, timedelta
 
-        last_update = get_setting_float('last_update', 0.0)
-        if last_update and not self._first_run():
-            last_update_dt = datetime.fromtimestamp(get_setting_float('last_update', 0.0))
-            if last_update_dt + timedelta(days=get_setting_int('update_frequency', 14)) >= datetime.utcnow():
-                log(2, 'Widevine update check was made on {date}', date=last_update_dt.isoformat())
+        last_check = get_setting_float('last_check', 0.0)
+        if last_check and not self._first_run():
+            last_check_dt = datetime.fromtimestamp(get_setting_float('last_check', 0.0))
+            if last_check_dt + timedelta(days=get_setting_int('update_frequency', 14)) >= datetime.utcnow():
+                log(2, 'Widevine update check was made on {date}', date=last_check_dt.isoformat())
                 return
 
         wv_config = load_widevine_config()
@@ -301,7 +302,7 @@ class Helper:
                 log(3, 'User declined to update {component}.', component=component)
         else:
             from time import mktime
-            set_setting('last_update', mktime(datetime.utcnow().timetuple()))
+            set_setting('last_check', mktime(datetime.utcnow().timetuple()))
             log(0, 'User is on the latest available {component} version.', component=component)
 
     def _check_widevine(self):

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -226,10 +226,9 @@ class Helper:
             return result
 
         if self.install_and_finish(*result):
-            from datetime import datetime
-            from time import mktime
-            set_setting('last_update', mktime(datetime.utcnow().timetuple()))
-            set_setting('last_check', mktime(datetime.utcnow().timetuple()))
+            from time import time
+            set_setting('last_update', time())
+            set_setting('last_check', time())
             return True
 
         ok_dialog(localize(30004), localize(30005))  # An error occurred
@@ -265,13 +264,12 @@ class Helper:
 
     def _update_widevine(self):
         """Prompts user to upgrade Widevine CDM when a newer version is available."""
-        from datetime import datetime, timedelta
+        from time import localtime, strftime, time
 
         last_check = get_setting_float('last_check', 0.0)
         if last_check and not self._first_run():
-            last_check_dt = datetime.fromtimestamp(get_setting_float('last_check', 0.0))
-            if last_check_dt + timedelta(days=get_setting_int('update_frequency', 14)) >= datetime.utcnow():
-                log(2, 'Widevine update check was made on {date}', date=last_check_dt.isoformat())
+            if last_check + 3600 * 24 * get_setting_int('update_frequency', 14) >= time():
+                log(2, 'Widevine update check was made on {date}', date=strftime('%Y-%m-%d %H:%M', localtime(last_check)))
                 return
 
         wv_config = load_widevine_config()
@@ -301,8 +299,7 @@ class Helper:
             else:
                 log(3, 'User declined to update {component}.', component=component)
         else:
-            from time import mktime
-            set_setting('last_check', mktime(datetime.utcnow().timetuple()))
+            set_setting('last_check', time())
             log(0, 'User is on the latest available {component} version.', component=component)
 
     def _check_widevine(self):
@@ -434,9 +431,9 @@ class Helper:
         if system_os() == 'Android':
             text += ' - ' + localize(30821) + '\n'
         else:
-            from datetime import datetime
+            from time import localtime, strftime
             if get_setting_float('last_update', 0.0):
-                wv_updated = datetime.fromtimestamp(get_setting_float('last_update', 0.0)).strftime("%Y-%m-%d %H:%M")
+                wv_updated = strftime('%Y-%m-%d %H:%M', localtime(get_setting_float('last_update', 0.0)))
             else:
                 wv_updated = 'Never'
             text += ' - ' + localize(30822, version=self._get_lib_version(widevinecdm_path()), date=wv_updated) + '\n'

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -4,9 +4,10 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import os
+from time import time
 
 from .. import config
-from ..kodiutils import addon_profile, exists, get_setting_int, listdir, localize, log, mkdirs, ok_dialog, open_file, translate_path, yesno_dialog
+from ..kodiutils import addon_profile, exists, get_setting_int, listdir, localize, log, mkdirs, ok_dialog, open_file, set_setting, translate_path, yesno_dialog
 from ..utils import arch, cmd_exists, hardlink, http_download, http_get, remove_tree, run_cmd, store, system_os
 from ..unicodes import compat_path, to_unicode
 
@@ -21,6 +22,7 @@ def install_cdm_from_backup(version):
         hardlink(backup_fpath, install_fpath)
 
     log(0, 'Installed CDM version {version} from backup', version=version)
+    set_setting('last_modified', time())
     remove_old_backups(backup_path())
 
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <setting id="last_update" value="0.0" visible="false"/>
+    <setting id="last_check" value="0.0" visible="false"/>
     <setting id="version" value="" visible="false"/>
     <category label="30900"> <!-- Expert -->
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-    <setting id="last_update" value="0.0" visible="false"/>
+    <setting id="last_modified" value="0.0" visible="false"/>
     <setting id="last_check" value="0.0" visible="false"/>
     <setting id="version" value="" visible="false"/>
     <category label="30900"> <!-- Expert -->

--- a/tests/userdata/addon_settings.json
+++ b/tests/userdata/addon_settings.json
@@ -5,7 +5,7 @@
     "inputstream.rtmp": {},
     "script.module.inputstreamhelper": {
         "disabled": "false",
-        "last_update": "",
+        "last_modified": "",
         "last_check": "",
         "temp_path": "special://masterprofile/addon_data/script.module.inputstreamhelper/ũnícødētèst",
         "update_frequency": "31",

--- a/tests/userdata/addon_settings.json
+++ b/tests/userdata/addon_settings.json
@@ -1,13 +1,14 @@
 {
     "inputstream.adaptive": {
         "DECRYPTERPATH": "special://home/cdm/ũnícødētèst"
-    }, 
-    "inputstream.rtmp": {}, 
+    },
+    "inputstream.rtmp": {},
     "script.module.inputstreamhelper": {
-        "disabled": "false", 
-        "last_update": "", 
-        "temp_path": "special://masterprofile/addon_data/script.module.inputstreamhelper/ũnícødētèst", 
-        "update_frequency": "31", 
+        "disabled": "false",
+        "last_update": "",
+        "last_check": "",
+        "temp_path": "special://masterprofile/addon_data/script.module.inputstreamhelper/ũnícødētèst",
+        "update_frequency": "31",
         "version": ""
     }
 }


### PR DESCRIPTION
This resolves the inconsistency between using last_update for when widevine was last installed and for when an update check was made.

This relates to #344.