### PR TITLE
Changes to Chrome OS recovery

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -281,7 +281,7 @@ class Helper:
             current_version = wv_config['version']
         else:
             component = 'Chrome OS'
-            current_version = select_best_chromeos_image(wv_config)['version']
+            current_version = wv_config['version']
 
         latest_version = latest_widevine_version()
         if not latest_version:
@@ -436,8 +436,7 @@ class Helper:
             if arch() in ('arm', 'arm64'):  # Chrome OS version
                 wv_cfg = load_widevine_config()
                 if wv_cfg:
-                    installed_img = select_best_chromeos_image(wv_cfg)
-                    text += localize(30822, name=installed_img['hwidmatch'].split()[0].lstrip('^'), version=installed_img['version']) + '\n'
+                    text += localize(30822, name=wv_cfg['hwidmatch'].split()[0].lstrip('^'), version=wv_cfg['version']) + '\n'
             if get_setting_float('last_check', 0.0):
                 wv_check = strftime('%Y-%m-%d %H:%M', localtime(get_setting_float('last_check', 0.0)))
             else:
@@ -462,10 +461,7 @@ class Helper:
             notification(localize(30004), localize(30041))
             return
 
-        if 'x86' in arch():
-            installed_version = load_widevine_config()['version']
-        else:
-            installed_version = select_best_chromeos_image(load_widevine_config())['version']
+        installed_version = load_widevine_config()['version']
         del versions[versions.index(installed_version)]
 
         if 'x86' in arch():

--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -308,7 +308,7 @@ class Helper:
             return True
 
         if not exists(widevine_config_path()):
-            log(4, 'Widevine or Chrome OS recovery.conf is missing. Reinstall is required.')
+            log(4, 'Widevine or Chrome OS recovery.json is missing. Reinstall is required.')
             ok_dialog(localize(30001), localize(30031))  # An update of Widevine is required
             return self.install_widevine()
 

--- a/lib/inputstreamhelper/config.py
+++ b/lib/inputstreamhelper/config.py
@@ -77,7 +77,7 @@ WIDEVINE_MANIFEST_FILE = 'manifest.json'
 
 WIDEVINE_CONFIG_NAME = 'manifest.json'
 
-CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.conf'
+CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.json'
 
 # Last updated: 2019-08-20 (version 12239.67.0)
 CHROMEOS_RECOVERY_ARM_HWIDS = [

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -73,7 +73,7 @@ def mnt_loop_dev():
 
 def select_best_chromeos_image(devices):
     """Finds the newest and smallest of the ChromeOS images given"""
-    log(0, 'Find best ARM image to use from the Chrome OS recovery.conf')
+    log(0, 'Find best ARM image to use from the Chrome OS recovery.json')
 
     best = None
     for device in devices:
@@ -118,24 +118,8 @@ def select_best_chromeos_image(devices):
 
 
 def chromeos_config():
-    """Parse the Chrome OS recovery configuration and put it in a dictionary"""
-    url = config.CHROMEOS_RECOVERY_URL
-    conf = [line for line in http_get(url).split('\n\n') if 'hwidmatch=' in line]
-
-    devices = []
-    for device in conf:
-        device_dict = dict()
-        for device_info in device.splitlines():
-            if not device_info:
-                continue
-            try:
-                key, value = device_info.split('=')
-                device_dict[key] = value
-            except ValueError:
-                continue
-        devices.append(device_dict)
-
-    return devices
+    """Reads the Chrome OS recovery configuration"""
+    return json.loads(http_get(config.CHROMEOS_RECOVERY_URL))
 
 
 def install_widevine_arm(backup_path):
@@ -143,7 +127,7 @@ def install_widevine_arm(backup_path):
     devices = chromeos_config()
     arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
-        log(4, 'We could not find an ARM device in the Chrome OS recovery.conf')
+        log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))
         return False
     # Estimated required disk space: takes into account an extra 20 MiB buffer
@@ -186,7 +170,7 @@ def install_widevine_arm(backup_path):
                     return install_wv_arm_legacy(backup_path)
                 return False
 
-            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
+            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
             with open_file(json_file, 'w') as config_file:
                 config_file.write(json.dumps(devices, indent=4))
 
@@ -201,7 +185,7 @@ def install_wv_arm_legacy(backup_path):
     devices = chromeos_config()
     arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
-        log(4, 'We could not find an ARM device in the Chrome OS recovery.conf')
+        log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))
         return False
     # Estimated required disk space: takes into account an extra 20 MiB buffer
@@ -279,7 +263,7 @@ def install_wv_arm_legacy(backup_path):
         if check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
             progress.update(96, message=localize(30048))  # Extracting Widevine CDM
             extract_widevine_from_img(os.path.join(backup_path, arm_device['version']))
-            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
+            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
             with open_file(json_file, 'w') as config_file:
                 config_file.write(json.dumps(devices, indent=4))
 

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -170,9 +170,12 @@ def install_widevine_arm(backup_path):
                     return install_wv_arm_legacy(backup_path)
                 return False
 
-            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
-            with open_file(json_file, 'w') as config_file:
-                config_file.write(json.dumps(devices, indent=4))
+            recovery_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
+            config_file = os.path.join(backup_path, arm_device['version'], 'config.json')
+            with open_file(recovery_file, 'w') as reco_file:
+                reco_file.write(json.dumps(devices, indent=4))
+            with open_file(config_file, 'w') as conf_file:
+                conf_file.write(json.dumps(arm_device))
 
             return (progress, arm_device['version'])
 

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -63,7 +63,7 @@ def widevine_config_path():
     """Return the full path to the widevine or recovery config file"""
     if 'x86' in arch():
         return os.path.join(ia_cdm_path(), config.WIDEVINE_CONFIG_NAME)
-    return os.path.join(ia_cdm_path(), os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
+    return os.path.join(ia_cdm_path(), os.path.basename(config.CHROMEOS_RECOVERY_URL))
 
 
 def load_widevine_config():
@@ -161,7 +161,7 @@ def latest_widevine_version(eula=False):
     devices = chromeos_config()
     arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
-        log(4, 'We could not find an ARM device in the Chrome OS recovery.conf')
+        log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))
         return ''
     return arm_device['version']

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -63,7 +63,7 @@ def widevine_config_path():
     """Return the full path to the widevine or recovery config file"""
     if 'x86' in arch():
         return os.path.join(ia_cdm_path(), config.WIDEVINE_CONFIG_NAME)
-    return os.path.join(ia_cdm_path(), os.path.basename(config.CHROMEOS_RECOVERY_URL))
+    return os.path.join(ia_cdm_path(), 'config.json')
 
 
 def load_widevine_config():
@@ -177,11 +177,7 @@ def remove_old_backups(bpath):
     if len(versions) < 2:
         return
 
-    if 'x86' in arch():
-        installed_version = load_widevine_config()['version']
-    else:
-        from .arm import select_best_chromeos_image
-        installed_version = select_best_chromeos_image(load_widevine_config())['version']
+    installed_version = load_widevine_config()['version']
 
     while len(versions) > max_backups + 1:
         remove_version = str(versions[1] if versions[0] == LooseVersion(installed_version) else versions[0])


### PR DESCRIPTION
This changes recovery.conf to recovery.json, which is easier to load (see changes to `chromeos_config()`) and should be more future proof, since recovery.json is also used by the "Chromebook recovery utility" addon for Chrome browser.
Additionally it also only saves the data of the chosen image instead of the whole recovery.json, making it easier to read (and saving a tiny bit of diskspace).