### PR TITLE
Optimize file operations

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -185,7 +185,7 @@ class Helper:
         if downloaded:
             progress = progress_dialog()
             progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
-            unzip(store('download_path'), os.path.join(bpath, cdm_version))
+            unzip(store('download_path'), os.path.join(bpath, cdm_version, ''))
 
             return (progress, cdm_version)
 

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -358,6 +358,7 @@ def delete(path):
 
 def exists(path):
     """Whether the path exists (using xbmcvfs)"""
+    # File or folder (folder must end with slash or backslash)
     from xbmcvfs import exists as vfsexists
     return vfsexists(from_unicode(path))
 

--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -21,8 +21,8 @@ from .unicodes import compat_path, from_unicode, to_unicode
 
 
 def temp_path():
-    """Return temporary path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp"""
-    tmp_path = translate_path(os.path.join(get_setting('temp_path', 'special://masterprofile/addon_data/script.module.inputstreamhelper'), 'temp'))
+    """Return temporary path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/"""
+    tmp_path = translate_path(os.path.join(get_setting('temp_path', 'special://masterprofile/addon_data/script.module.inputstreamhelper'), 'temp', ''))
     if not exists(tmp_path):
         mkdirs(tmp_path)
 

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -14,10 +14,10 @@ from ..unicodes import compat_path, to_unicode
 from .arm_chromeos import ChromeOSImage
 
 
-def mnt_path():
-    """Return mount path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/mnt"""
-    mount_path = os.path.join(temp_path(), 'mnt')
-    if not exists(mount_path):
+def mnt_path(make=True):
+    """Return mount path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/mnt/"""
+    mount_path = os.path.join(temp_path(), 'mnt', '')
+    if make and not exists(mount_path):
         mkdir(mount_path)
 
     return mount_path
@@ -294,7 +294,7 @@ def extract_widevine_from_img(backup_path):
 
 def unmount():
     """Unmount mountpoint if mounted"""
-    while os.path.ismount(compat_path(mnt_path())):
+    while os.path.ismount(compat_path(mnt_path(make=False))):
         log(0, 'Unmount {mountpoint}', mountpoint=mnt_path())
         umount_output = run_cmd(['umount', compat_path(mnt_path())], sudo=True)
         if not umount_output['success']:

--- a/lib/inputstreamhelper/widevine/arm_chromeos.py
+++ b/lib/inputstreamhelper/widevine/arm_chromeos.py
@@ -303,8 +303,9 @@ class ChromeOSImage:
         block_ids_sorted.sort()
         block_dict = self.read_file(block_ids_sorted)
 
-        if not exists(os.path.dirname(filepath)):
-            mkdirs(os.path.dirname(filepath))
+        write_dir = os.path.join(os.path.dirname(filepath), '')
+        if not exists(write_dir):
+            mkdirs(write_dir)
 
         with open(compat_path(filepath), 'wb') as opened_file:
             for block_id in block_ids:

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -53,7 +53,7 @@ def widevine_eula():
 
 def backup_path():
     """Return the path to the cdm backups"""
-    path = os.path.join(addon_profile(), 'backup')
+    path = os.path.join(addon_profile(), 'backup', '')
     if not exists(path):
         mkdirs(path)
     return path
@@ -111,7 +111,7 @@ def ia_cdm_path():
     except RuntimeError:
         return None
 
-    cdm_path = translate_path(to_unicode(addon.getSetting('DECRYPTERPATH')))
+    cdm_path = translate_path(os.path.join(to_unicode(addon.getSetting('DECRYPTERPATH')), ''))
     if not exists(cdm_path):
         mkdirs(cdm_path)
 


### PR DESCRIPTION
This pull request adds optimizations to reduce the load on the file system:
- bugfix: add trailing file system separator (slash/backslash) to folder paths because `xbmcvfs.exists` needs this to succesfully check if a folder exists
- only create mount path when it will be used