### PR TITLE
Remove PHASER from ARM HWID list

### DIFF
--- a/lib/inputstreamhelper/config.py
+++ b/lib/inputstreamhelper/config.py
@@ -99,8 +99,6 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'MICKEY',
     'MIGHTY',
     'MINNIE',
-    'PHASER',
-    'PHASER360',
     'PI',
     'PIT',
     'RELM',


### PR DESCRIPTION
Apparently we have two incorrect Chromebook product types in our ARM
HWID list. We should probably investigate the others as well, and expand
the list with newer devices as well.

The incorrect HWIDs were:
- PHASER: MediaTek architecture
- PHASER360: Celeron architecture

This fixes #395 