### PR TITLE
Prepare for v0.5.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,30 +90,35 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
-## v0.5.0 (2020-06-25)
+### v0.5.1 (2020-10-02)
+- Fix incorrect ARM HWIDs: PHASER and PHASER360 (@dagwieers)
+- Added Hebrew translations (@haggaie)
+- Updated Dutch, Japanese and Korean translations (@michaelarnauts, @Thunderbird2086)
+
+### v0.5.0 (2020-06-25)
 - Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access (@horstle)
 - Improve progress dialog while extracting Widevine CDM on ARM devices (@horstle, @mediaminister)
 - Support resuming interrupted downloads on unreliable internet connections (@horstle, @mediaminister)
 - Reshape InputStream Helper information dialog (@horstle, @dagwieers)
 - Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations (@dagwieers, @horstle, @mediaminister, @tweimer, @Twilight0, @frodo19, @tmihai20, @vlmaksime, @roliverosc, @Sopor)
 
-## v0.4.7 (2020-05-03)
+### v0.4.7 (2020-05-03)
 - Fix hardlink on Windows (@BarmonHammer)
 - Fix support for unicode chars in paths (@mediaminister)
 - Show remaining time during Widevine installation on ARM devices (@horstle)
 
-## v0.4.6 (2020-04-29)
+### v0.4.6 (2020-04-29)
 - Compatibility fixes for Kodi 19 Matrix "pre-release" builds (@mediaminister)
 - Optimize Widevine CDM detection (@dagwieers)
 - Minor fixes for Widevine installation on ARM devices (@dagwieers @mediaminister @horstle)
 
-## v0.4.5 (2020-04-07)
+### v0.4.5 (2020-04-07)
 - Added Spanish and Romanian translations (@roliverosc, @tmihai20)
 - Added support for Kodi 19 Matrix "pre-release" builds (@mediaminister)
 - Fix Widevine backups when using an external drive (@horstle)
 - Various fixes for Widevine installation on ARM devices (@horstle)
 
-## v0.4.4 (2020-03-01)
+### v0.4.4 (2020-03-01)
 - Added option to restore a previously installed Widevine version (@horstle)
 - Improve progress bar when extracting Widevine on ARM devices (@dagwieers)
 - Improve Widevine library version detection (@dagwieers, @mediaminister)
@@ -123,7 +128,7 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Updated existing translations (@dnicolaas, @Sopor, @tweimer, @horstle, @mediaminister)
 - Various small bugfixes for Widevine installation on ARM devices (@dagwieers, @mediaminister, @Twilight0, @janhicken)
 
-## v0.4.3 (2019-09-25)
+### v0.4.3 (2019-09-25)
 - French translation (@brunoduc)
 - Updated translations (@vlmaksime, @dagwieers, @pinoelefante, @horstle, @Twilight0, @emilsvennesson)
 - Ensure Kodi 19 compatibility (@mediaminister)
@@ -132,7 +137,7 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Fix add-on settings crashes when InputStream Adaptive is missing (@mediaminister)
 - Improve unicode character support (@mediaminister)
 
-## v0.4.2 (2019-09-03)
+### v0.4.2 (2019-09-03)
 - Move release history to readme file (@mediaminister)
 - Clean up coverage/codecov config (@dagwieers)
 - Add InputStream Helper Information to settings page (@horstle, @dagwieers)
@@ -143,14 +148,14 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Fix unresponsive Kodi when opening add-on information pane (@dagwieers, @mediaminister)
 - Add-on structure improvements (@dagwieers)
 
-## v0.4.1 (2019-09-01)
+### v0.4.1 (2019-09-01)
 - Follow kodi-addon-checker recommended code changes (@mediaminister)
 - Implement api using runscript (@mediaminister)
 - Fix ARM processing in unittest locally (@dagwieers)
 - Add more project information (@dagwieers)
 - More coverage improvements (@dagwieers)
 
-## v0.4.0 (2019-09-01)
+### v0.4.0 (2019-09-01)
 - Use local url variable (@mediaminister)
 - Directly use Kodi CDM directory (@mediaminister)
 - Implement settings menu and API (@dagwieers)
@@ -172,12 +177,12 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Russian translation (@vlmaksime)
 - Swedish translation (@emilsvennesson)
 
-## v0.3.5 (2019-08-15)
+### v0.3.5 (2019-08-15)
 - Auto install inputstream.adaptive (@mediaminister)
 - Fix latest Widevine version detection (@dagwieers)
 - Check for Widevine updates on new release (@mediaminister)
 
-## v0.3.4 (2019-03-23)
+### v0.3.4 (2019-03-23)
 - python2_3 compability (@mediaminister, @Rechi)
 - Option to disable inputstreamhelper in settings.xml
 - calculate disk space on the tmp folder (@dawez)
@@ -187,7 +192,7 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Greek translation (@Twilight0)
 - Russian translation (@vlmaksime)
 
-## v0.3.3 (2018-02-21)
+### v0.3.3 (2018-02-21)
 - Load loop if it's a kernel module (@mkreisl)
 - Fix legacy Widevine CDM update detection
 - inputstream_addon is now a public variable
@@ -195,35 +200,35 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Improve logging
 - Cosmetics
 
-## v0.3.2 (2018-01-30)
+### v0.3.2 (2018-01-30)
 - Fix OSMC arm architecture detection
 - Fix ldd permissions error
 
-## v0.3.1 (2018-01-29)
+### v0.3.1 (2018-01-29)
 - check_inputstream() return fix
 
-## v0.3.0 (2018-01-29)
+### v0.3.0 (2018-01-29)
 - Bug fix: module left xbmcaddon class in memory
 - Keep Widevine CDM up-to-date with the latest version available (Kodi 18 and higher)
 - Check for missing depending libraries by parsing the output from ldd
 - Use older Widevine binaries on Kodi Krypton (fixes nss/nspr dependency issues)
 
-## v0.2.4 (2018.01.01)
+### v0.2.4 (2018.01.01)
 - Fix ARM download on systems with sudo (OSMC etc)
 - Actually bump version in addon.xml, unlike v0.2.3...
 
-## v0.2.3 (2017-12-30)
+### v0.2.3 (2017-12-30)
 - Make sure Kodi and Widevine CDM binary architecture matches
 - Minor wording changes/fixes
 
-## v0.2.2 (2017-12-05)
+### v0.2.2 (2017-12-05)
 - Fixes for widevine download when using 64-bit Kodi (@gismo112, @asciidisco)
 
-## v0.2.1 (2017-10-15)
+### v0.2.1 (2017-10-15)
 - Update German translation (@asciidisco)
 - Improve root permissions acquisition
 
-## v0.2.0 (2017-09-29)
+### v0.2.0 (2017-09-29)
 - Automatic Widevine CDM download on ARM devices
 - Display Widevine EULA during installation procedure
 - German translation (thanks to asciidisco)
@@ -231,5 +236,5 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Better exception handling
 - Code cleanup
 
-## v0.1.0 (2017-09-13)
+### v0.1.0 (2017-09-13)
 - Initial release

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="2.25.0"/>
@@ -23,12 +23,17 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
-     v0.5.0 (2020-06-25)
-        - Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
-        - Improve progress dialog while extracting Widevine CDM on ARM devices
-        - Support resuming interrupted downloads on unreliable internet connections
-        - Reshape InputStream Helper information dialog
-        - Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
+v0.5.1 (2020-10-02)
+- Fix incorrect ARM HWIDs: PHASER and PHASER360
+- Added Hebrew translations
+- Updated Dutch, Japanese and Korean translations
+
+v0.5.0 (2020-06-25)
+- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
+- Improve progress dialog while extracting Widevine CDM on ARM devices
+- Support resuming interrupted downloads on unreliable internet connections
+- Reshape InputStream Helper information dialog
+- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
     </news>
     <platform>all</platform>
     <license>MIT</license>


### PR DESCRIPTION
This is an emergency release to fix an incorrect Widevine download
breaking existing ARM setups.