### PR TITLE
Log when we download a new ChromeOS ARM image

### DIFF
--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -147,6 +147,7 @@ def install_widevine_arm(backup_path):
                       localize(30018, diskspace=sizeof_fmt(required_diskspace)))
             return False
 
+        log(2, 'Downloading best ChromeOS image for Widevine: {hwid} ({version})'.format(**arm_device))
         url = arm_device['url']
         downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
                                    dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image


### PR DESCRIPTION
This is crucial for our ARM users to understand a new Widevine was installed from a specific ChromeOS image.

Having this will make it much easier for users to idenfity the cause of their recent problems, as well as help us identify the affected ChromeOS image in case of issues.