### PR TITLE
Submit releases automatically to Kodi repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,16 @@ jobs:
           asset_name: ${{ steps.get-matrix-filename.outputs.matrix-filename }}
           asset_path: ../${{ steps.get-matrix-filename.outputs.matrix-filename }}
           asset_content_type: application/zip
+      - name: Generate distribution zip and submit to official kodi repository
+        id: kodi-addon-submitter
+        uses: xbmc/action-kodi-addon-submitter@v1.2
+        with:
+          kodi-repository: repo-scripts
+          kodi-version: krypton
+          addon-id: script.module.inputstreamhelper
+          kodi-matrix: true
+        env:
+          GH_USERNAME: ${{secrets.GH_USERNAME}}
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
+          EMAIL: ${{secrets.EMAIL}}
+


### PR DESCRIPTION
This adds automatic submission of releases to https://github.com/xbmc/repo-scripts/ based on https://github.com/xbmc/action-kodi-addon-submitter

To make this functional, three secrets must be configured in this repo:
- EMAIL
- GH_USERNAME
- GH_TOKEN (needs public_repo scope and can be created at https://github.com/settings/tokens/new)

When pushing a new version tag (e. g. v0.5.2) to this repo, PR's will automatically be created at https://github.com/xbmc/repo-scripts/