### PR TITLE
Fix invalid setting type

### DIFF
--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -193,14 +193,11 @@ def get_setting_int(key, default=None):
 
 def get_setting_float(key, default=None):
     """Get an add-on setting as float"""
+    value = get_setting(key, default)
     try:
-        return ADDON.getSettingNumber(key)
-    except (AttributeError, TypeError):  # On Krypton or older, or when not a float
-        value = get_setting(key, default)
-        try:
-            return float(value)
-        except ValueError:
-            return default
+        return float(value)
+    except ValueError:
+        return default
     except RuntimeError:  # Occurs when the add-on is disabled
         return default
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-    <setting id="last_modified" value="0.0" visible="false"/>
-    <setting id="last_check" value="0.0" visible="false"/>
-    <setting id="version" value="" visible="false"/>
     <category label="30900"> <!-- Expert -->
+        <setting id="last_modified" default="0.0" visible="false"/>
+        <setting id="last_check" default="0.0" visible="false"/>
+        <setting id="version" default="" visible="false"/>
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>


### PR DESCRIPTION
This fixes https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/388

I guess `xbmcaddon.getSettingNumber` isn't functional because you can only define an integer type in the Kodi addon settings xml and in addition it is wrongly named as `type="number"`.

Maybe this can be fixed upstream if Team Kodi still accepts changes to the deprecated old settings format:
https://kodi.wiki/view/Add-on_settings#type.3D.22number.22

Relevant source code
https://github.com/xbmc/xbmc/blob/5230b683323ca58c62459a371c1306a6cb4d4644/xbmc/addons/settings/AddonSettings.cpp#L832-L844

`setting->GetType() `can never be a `SettingType::Number`, so it differs from `TSetting::Type()` and returns false
https://github.com/xbmc/xbmc/blob/c4de26b28fb13ce65eb1caac4236d83bd410d112/xbmc/addons/Addon.cpp#L206