### PR TITLE
Check Chrome OS recovery images availability

### DIFF
--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -1,0 +1,29 @@
+# This workflow checks Chrome OS recovery images availability status
+
+name: Status
+on:
+  pull_request:
+  push:
+  schedule:
+  - cron:  '0 5 * * 3'
+jobs:
+  tests:
+    name: Checks
+    runs-on: ubuntu-latest
+    env:
+      PYTHONIOENCODING: utf-8
+      PYTHONPATH: ${{ github.workspace }}/resources/lib:${{ github.workspace }}/tests
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Check Chrome OS recovery images availability
+      run: python -m tests.checkchromeos
+      if: always()

--- a/tests/checkchromeos.py
+++ b/tests/checkchromeos.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Check Chrome OS recovery images availability"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+from xml.etree import ElementTree as ET
+import requests
+from lib.inputstreamhelper.config import CHROMEOS_RECOVERY_ARM_HWIDS
+
+def get_devices():
+    """Get Chrome OS devices as json object"""
+    url = 'https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices'
+    html = requests.get(url).text.split('<table id="goog-ws-list-table"')[1].split('</table>')[0]
+    html = '<table id="goog-ws-list-table"' + html + '</table>'
+    table = ET.XML(html.encode('utf-8'))
+    keys = [k.text for k in table[0][0]]
+    devices = []
+    for row in table[1]:
+        device = dict()
+        for num, value in enumerate(row):
+            device[keys[num]] = None
+            if value.text:
+                device[keys[num]] = value.text.strip()
+            elif list(value)[0].text:
+                device[keys[num]] = list(value)[0].text.strip()
+        devices.append(device)
+    return devices
+
+def get_arm_devices():
+    """Get Chrome OS ARM devices as json object"""
+    devices = get_devices()
+    arm_devices = []
+    for device in devices:
+        if device.get('User ABI') == 'arm':
+            arm_devices.append(device)
+    return arm_devices
+
+def get_serves():
+    """Get Chrome OS serving updates as json object"""
+    url = 'https://cros-updates-serving.appspot.com/csv'
+    csv = requests.get(url).text
+    keys = list(csv.split('\n')[0].split(','))
+    serves = []
+    for row in csv.split('\n')[1:]:
+        serve = dict()
+        for num, value in enumerate(row.split(',')):
+            serve[keys[num]] = value
+        serves.append(serve)
+    return serves
+
+def get_recoveries():
+    """Get Chrome OS recovery items as json object"""
+    url = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.json'
+    recoveries = requests.get(url).json()
+    return recoveries
+
+def get_compatibles():
+    """Get compatible Chrome OS recovery items"""
+    arm_devices = get_arm_devices()
+    serves = get_serves()
+    recoveries = get_recoveries()
+    boards = []
+    compatibles = []
+    for device in arm_devices:
+        full_board = device.get('Board name(s)').lower()
+        if '_' in full_board:
+            board = full_board.split('_')[1]
+        else:
+            board = full_board
+        for serve in serves:
+            if board == serve.get('board') and serve.get('eol') == 'False' and board not in boards:
+                boards.append(board)
+                for recovery in recoveries:
+                    r_board = recovery.get('file').split('_')[2]
+                    if '-' in r_board:
+                        r_board = r_board.replace('-', '_')
+                    if full_board == r_board:
+                        compatibles.append(recovery)
+    return compatibles
+
+def get_smallest():
+    """Get the Chrome OS recovery item with the smallest filesize"""
+    compatibles = get_compatibles()
+    smallest = None
+    for item in compatibles:
+        if smallest is None:
+            smallest = item
+        if (int(item.get('filesize')) + int(item.get('zipfilesize')) <
+                int(smallest.get('filesize')) + int(smallest.get('zipfilesize'))):
+            smallest = item
+    return smallest
+
+
+def check_hwids():
+    """Check if hardware id's in inputstreamhelper.config are up to date"""
+    compatibles = get_compatibles()
+    hwids = []
+    messages = []
+    for compatible in compatibles:
+        hwid = compatible.get('hwidmatch').strip('^.*').split(' ')[0]
+        if hwid not in hwids:
+            hwids.append(hwid)
+
+    for item in CHROMEOS_RECOVERY_ARM_HWIDS:
+        if item not in hwids:
+            messages.append('%s is end of life, please remove it from inputstreamhelper config' % item)
+    for item in hwids:
+        if item not in CHROMEOS_RECOVERY_ARM_HWIDS:
+            messages.append('%s is missing, please add it to inputstreamhelper config' % item)
+    if messages:
+        raise Exception(messages)
+
+    smallest = get_smallest()
+    hwid = smallest.get('hwidmatch').strip('^.*').split(' ')[0]
+    print('Chrome OS hardware id\'s are up to date, current smallest recovery image is %s' % hwid)
+
+def run():
+    """Main function"""
+    check_hwids()
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
This PR ads a daily status check to the github workflow to determine Chrome OS recovery image availability and includes the following features:
- status check fails when inputstreamhelper config contains missing or outdated(EOL) hardware id's
- status check succeeds when  inputstreamhelper config is up to date
- shows a message with the hardware id with  the smallest recovery image

This should fix https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/414
