### PR TITLE
Install older Widevine CDM when OS doesn't have TCMalloc support

### DIFF
--- a/lib/inputstreamhelper/config.py
+++ b/lib/inputstreamhelper/config.py
@@ -67,6 +67,14 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
     'Darwin': '18.0'
 }
 
+HARDCODED_CHROMEOS_IMAGE = {
+    'hwid': 'FIEVEL',
+    'url': 'https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_13505.73.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip',
+    'sha1': '9904e3141a2537f28469c7653c62200c1b03b057',
+    'version': '13505.73.0',
+    'zipfilesize': '1032442523'
+}
+
 WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
 
 WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -65,6 +65,16 @@ def kodi_version_major():
     return int(kodi_version().split('.')[0])
 
 
+def kodi_os():
+    """Returns Kodi OS name as string"""
+    # It takes a while to get this info
+    count = 0
+    while ' (kernel: ' not in xbmc.getInfoLabel('System.OSVersionInfo') and count < 10:
+        count += 1
+        xbmc.sleep(100)
+    return xbmc.getInfoLabel('System.OSVersionInfo').split(' (kernel: ')[0]
+
+
 def translate_path(path):
     """Translate special xbmc paths"""
     return to_unicode(translatePath(from_unicode(path)))

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -269,6 +269,19 @@ msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr ""
 
+msgctxt "#30066"
+msgid "Warning"
+msgstr ""
+
+msgctxt "#30067"
+msgid "{os} probably doesn't support the newest Widevine CDM. Would you try to install an older Widevine CDM instead?"
+msgstr ""
+
+msgctxt "#30068"
+msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's on May 31, 2021."
+msgstr ""
+
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -24,7 +24,8 @@ LOGNONE = 7
 
 INFO_LABELS = {
     'Container.FolderPath': 'plugin://' + ADDON_ID + '/',
-    'System.BuildVersion': '18.2',
+    'System.BuildVersion': '18.9',
+    'System.OSVersionInfo': 'Linux (kernel: Linux 5.4.0-73-generic)',
 }
 
 REGIONS = {


### PR DESCRIPTION
With the release of Widevine CDM 4.10.2252.0, Google uses a newer dynamic library that needs an operating system with TCMalloc support and a patched glibc to work. Support for this already implemented in LibreELEC and CoreELEC:
https://github.com/LibreELEC/LibreELEC.tv/pull/5376
https://github.com/CoreELEC/CoreELEC/pull/287

LibreELEC will release a new version supporting the new Widevine CDM: https://github.com/LibreELEC/LibreELEC.tv/pull/5399

 This PR tries to handle some problems InputStreamHelper users will run into.

This PR includes:
- propose the user to install an older Widevine CDM when `libtcmalloc_minimal.so` is not found.
- warn the user that Google will remove support for older Widevine CDM's on 31 May, 2021 when installing older CDM's