### PR TITLE
Remove TLS 64-byte alignment detection

### DIFF
--- a/lib/inputstreamhelper/config.py
+++ b/lib/inputstreamhelper/config.py
@@ -67,15 +67,6 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
     'Darwin': '18.0'
 }
 
-HARDCODED_CHROMEOS_IMAGE = {
-    'hwid': 'FIEVEL',
-    'hwidmatch': '^FIEVEL .*',
-    'url': 'https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_13505.73.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip',
-    'sha1': '9904e3141a2537f28469c7653c62200c1b03b057',
-    'version': '13505.73.0',
-    'zipfilesize': '1032442523'
-}
-
 WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
 
 WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -160,13 +160,9 @@ def latest_widevine_version(eula=False):
         versions = http_get(url)
         return versions.split()[-1]
 
-    from .arm import chromeos_config, hardcoded_chromeos_image, select_best_chromeos_image, supports_widevine_arm64tls
-    # Return hardcoded Chrome OS version for systems not supporting newer Widevine CDM's
-    if not supports_widevine_arm64tls():
-        arm_device = hardcoded_chromeos_image()
-    else:
-        devices = chromeos_config()
-        arm_device = select_best_chromeos_image(devices)
+    from .arm import chromeos_config, select_best_chromeos_image
+    devices = chromeos_config()
+    arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
         log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -257,14 +257,6 @@ msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr ""
 
-msgctxt "#30066"
-msgid "Warning"
-msgstr ""
-
-msgctxt "#30067"
-msgid "{os} probably doesn't support the newest Widevine CDM and Google removed support for older Widevine CDM's on Sep 1, 2021. Do you wish to continue?"
-msgstr ""
-
 
 ### INFORMATION DIALOG
 msgctxt "#30800"


### PR DESCRIPTION
There is only one working Widevine CDM for ARM systems today and it needs a system that supports TLS 64-byte alignment. It doesn't make a lot of sense for ISH to detect if the users system is compatible. If not , Widevine will definitely fail and users should upgrade their system anyway.