### PR TITLE
Improve version checks

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -9,7 +9,7 @@ from . import config
 from .kodiutils import (addon_version, delete, exists, get_proxies, get_setting, get_setting_bool, get_setting_float, get_setting_int, jsonrpc,
                         kodi_to_ascii, kodi_version, listdir, localize, log, notification, ok_dialog, progress_dialog, select_dialog,
                         set_setting, set_setting_bool, textviewer, translate_path, yesno_dialog)
-from .utils import arch, http_download, remove_tree, store, system_os, temp_path, unzip
+from .utils import arch, http_download, parse_version, remove_tree, store, system_os, temp_path, unzip
 from .widevine.arm import install_widevine_arm
 from .widevine.widevine import (backup_path, has_widevinecdm, ia_cdm_path, install_cdm_from_backup, latest_available_widevine_from_repo,
                                 latest_widevine_version, load_widevine_config, missing_widevine_libs, widevine_config_path, widevine_eula, widevinecdm_path)
@@ -155,8 +155,7 @@ class Helper:
             ok_dialog(localize(30004), localize(30011, os=system_os()))  # Operating system not supported by Widevine
             return False
 
-        from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-        if LooseVersion(config.WIDEVINE_MINIMUM_KODI_VERSION[system_os()]) > LooseVersion(kodi_version()):
+        if parse_version(config.WIDEVINE_MINIMUM_KODI_VERSION[system_os()]) > parse_version(kodi_version()):
             log(4, 'Unsupported Kodi version for Widevine: {version}', version=kodi_version())
             ok_dialog(localize(30004), localize(30010, version=config.WIDEVINE_MINIMUM_KODI_VERSION[system_os()]))  # Kodi too old
             return False
@@ -251,8 +250,7 @@ class Helper:
         settings_version = get_setting('version', '0.3.4')  # settings_version didn't exist in version 0.3.4 and older
 
         # Compare versions
-        from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-        if LooseVersion(addon_version()) > LooseVersion(settings_version):
+        if parse_version(addon_version()) > parse_version(settings_version):
             # New version found, save addon_version to settings
             set_setting('version', addon_version())
             log(2, 'InputStreamHelper version {version} is running for the first time', version=addon_version())
@@ -293,8 +291,7 @@ class Helper:
         log(0, 'Latest {component} version is {version}', component=component, version=latest_version)
         log(0, 'Current {component} version installed is {version}', component=component, version=current_version)
 
-        from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-        if LooseVersion(latest_version) > LooseVersion(current_version):
+        if parse_version(latest_version) > parse_version(current_version):
             log(2, 'There is an update available for {component}', component=component)
             if yesno_dialog(localize(30040), localize(30033), nolabel=localize(30028), yeslabel=localize(30034)):
                 self.install_widevine()
@@ -340,8 +337,7 @@ class Helper:
 
     def _supports_hls(self):
         """Return if HLS support is available in inputstream.adaptive."""
-        from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-        if LooseVersion(self._inputstream_version()) >= LooseVersion(config.HLS_MINIMUM_IA_VERSION):
+        if parse_version(self._inputstream_version()) >= parse_version(config.HLS_MINIMUM_IA_VERSION):
             return True
 
         log(3, 'HLS is unsupported on {addon} version {version}', addon=self.inputstream_addon, version=self._inputstream_version())

--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -329,3 +329,13 @@ def remove_tree(path):
     """Remove an entire directory tree"""
     from shutil import rmtree
     rmtree(compat_path(path))
+
+
+def parse_version(version):
+    """Parse a version string and return a comparable version object"""
+    try:
+        from packaging.version import parse
+        return parse(version)
+    except ImportError:
+        from distutils.version import LooseVersion
+        return LooseVersion(version)

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -8,7 +8,7 @@ import json
 
 from .. import config
 from ..kodiutils import browsesingle, localize, log, ok_dialog, open_file, progress_dialog, yesno_dialog
-from ..utils import diskspace, http_download, http_get, sizeof_fmt, store, system_os, update_temp_path
+from ..utils import diskspace, http_download, http_get, parse_version, sizeof_fmt, store, system_os, update_temp_path
 from .arm_chromeos import ChromeOSImage
 
 
@@ -38,15 +38,14 @@ def select_best_chromeos_image(devices):
             continue
 
         # Select the newest version
-        from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-        if LooseVersion(device['version']) > LooseVersion(best['version']):
+        if parse_version(device['version']) > parse_version(best['version']):
             log(0, '{device[hwid]} ({device[version]}) is newer than {best[hwid]} ({best[version]})',
                 device=device,
                 best=best)
             best = device
 
         # Select the smallest image (disk space requirement)
-        elif LooseVersion(device['version']) == LooseVersion(best['version']):
+        elif parse_version(device['version']) == parse_version(best['version']):
             if int(device['filesize']) + int(device['zipfilesize']) < int(best['filesize']) + int(best['zipfilesize']):
                 log(0, '{device[hwid]} ({device_size}) is smaller than {best[hwid]} ({best_size})',
                     device=device,

--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -8,7 +8,7 @@ from time import time
 
 from .. import config
 from ..kodiutils import addon_profile, exists, get_setting_int, listdir, localize, log, mkdirs, ok_dialog, open_file, set_setting, translate_path, yesno_dialog
-from ..utils import arch, cmd_exists, hardlink, http_download, http_get, http_head, remove_tree, run_cmd, store, system_os
+from ..utils import arch, cmd_exists, hardlink, http_download, http_get, http_head, parse_version, remove_tree, run_cmd, store, system_os
 from ..unicodes import compat_path, to_unicode
 
 
@@ -186,10 +186,8 @@ def latest_available_widevine_from_repo():
 
 def remove_old_backups(bpath):
     """Removes old Widevine backups, if number of allowed backups is exceeded"""
-    from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-
     max_backups = get_setting_int('backups', 4)
-    versions = sorted([LooseVersion(version) for version in listdir(bpath)])
+    versions = sorted([parse_version(version) for version in listdir(bpath)])
 
     if len(versions) < 2:
         return
@@ -197,9 +195,9 @@ def remove_old_backups(bpath):
     installed_version = load_widevine_config()['version']
 
     while len(versions) > max_backups + 1:
-        remove_version = str(versions[1] if versions[0] == LooseVersion(installed_version) else versions[0])
+        remove_version = str(versions[1] if versions[0] == parse_version(installed_version) else versions[0])
         log(0, 'Removing oldest backup which is not installed: {version}', version=remove_version)
         remove_tree(os.path.join(bpath, remove_version))
-        versions = sorted([LooseVersion(version) for version in listdir(bpath)])
+        versions = sorted([parse_version(version) for version in listdir(bpath)])
 
     return


### PR DESCRIPTION
`distutils` module is deprecated in Python 3.10: https://www.python.org/dev/peps/pep-0632/
PEP 632 recommends using `packaging.version` which is part of `setuptools`, but this is not a part of the standard Python library.
To support Kodi systems (e.g. Windows) that don't have `setuptools` installed, a fallback to `disutils` is still needed.