### PR TITLE
Interpret http-get feedback as utf-8 (issue #495)

### DIFF
--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -70,7 +70,7 @@ def http_get(url):
     content = req.read()
     # NOTE: Do not log reponse (as could be large)
     # log(0, 'Response: {response}', response=content)
-    return content.decode()
+    return content.decode("utf-8")
 
 
 def http_head(url):


### PR DESCRIPTION
I tried the [proposal from DokuroKM](https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/495#issuecomment-1065477688) in issue #495, and this helped. 
I think the root cause is, that google changed the format of the information which the input stream helper uses to check the latest available widevine version.

On my system after the change of the local file `~/.kodi/addons/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py` the widevine update dialog was shown correctly and I was able to update. After the update everything worked as intented.

Can please someone review that and check that it has no side effects? 

