### PR TITLE
Initial support of 64bit userspace on ARM

### DIFF
--- a/lib/inputstreamhelper/__init__.py
+++ b/lib/inputstreamhelper/__init__.py
@@ -9,7 +9,7 @@ from . import config
 from .kodiutils import (addon_version, browsesingle, delete, exists, get_proxies, get_setting, get_setting_bool, get_setting_float, get_setting_int, jsonrpc,
                         kodi_to_ascii, kodi_version, listdir, localize, log, notification, ok_dialog, progress_dialog, select_dialog,
                         set_setting, set_setting_bool, textviewer, translate_path, yesno_dialog)
-from .utils import arch, http_download, parse_version, remove_tree, store, system_os, temp_path, unzip
+from .utils import arch, http_download, parse_version, remove_tree, store, system_os, temp_path, unzip, userspace64
 from .widevine.arm import dl_extract_widevine, extract_widevine, install_widevine_arm
 from .widevine.widevine import (backup_path, has_widevinecdm, ia_cdm_path, install_cdm_from_backup, latest_available_widevine_from_repo,
                                 latest_widevine_version, load_widevine_config, missing_widevine_libs, widevine_config_path, widevine_eula, widevinecdm_path)
@@ -135,19 +135,24 @@ class Helper:
             return False
         return True
 
-    @staticmethod
-    def _supports_widevine():
+    def _supports_widevine(self):
         """Checks if Widevine is supported on the architecture/operating system/Kodi version."""
         if arch() not in config.WIDEVINE_SUPPORTED_ARCHS:
             log(4, 'Unsupported Widevine architecture found: {arch}', arch=arch())
             ok_dialog(localize(30004), localize(30007, arch=arch()))  # Widevine not available on this architecture
             return False
 
-        if arch() == 'arm64' and system_os() != 'Android':
-            import struct
-            if struct.calcsize('P') * 8 == 64:
-                log(4, 'Unsupported 64-bit userspace found. User needs 32-bit userspace on {arch}', arch=arch())
-                ok_dialog(localize(30004), localize(30039))  # Widevine not available on ARM64
+        if arch() == 'arm64' and system_os() != 'Android' and userspace64():
+            is_version = parse_version(addon_version(self.inputstream_addon))
+            try:
+                compat_version = parse_version(config.MINIMUM_INPUTSTREAM_VERSION_ARM64[self.inputstream_addon])
+            except KeyError:
+                log(4, 'Minimum version of {addon} for 64bit support unknown. Continuing into the unknown...'.format(addon=self.inputstream_addon))
+                compat_version = parse_version("0.0.0")
+
+            if is_version < compat_version:
+                log(4, 'Unsupported 64bit userspace found. Needs 32bit or newer ISA (currently {v}) on {arch}', arch=arch(), v=is_version)
+                ok_dialog(localize(30004), localize(30068, addon=self.inputstream_addon, version=compat_version))  # Need newer ISA or 32bit userspace
                 return False
 
         if system_os() not in config.WIDEVINE_SUPPORTED_OS:

--- a/lib/inputstreamhelper/config.py
+++ b/lib/inputstreamhelper/config.py
@@ -79,10 +79,10 @@ WIDEVINE_CONFIG_NAME = 'manifest.json'
 
 CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.json'
 
-# To keep the Chrome OS ARM hardware ID list up to date, the following resources can be used:
+# To keep the Chrome OS ARM(64) hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://chromiumdash.appspot.com/serving-builds?deviceCategory=Chrome%20OS
-# Last updated: 2022-11-17
+# Last updated: 2023-03-24
 CHROMEOS_RECOVERY_ARM_HWIDS = [
     'BOB',
     'BURNET',
@@ -106,16 +106,10 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'KATSU',
     'KENZO-IGRW',
     'KEVIN',
-    'KINGOFTOWN-KDDA',
     'KODAMA',
     'KRANE-ZDKS',
-    'LAZOR',
-    'LIMOZEEN',
     'MAKOMO-UTTX',
-    'PAZQUEL-HGNV',
-    'PAZQUEL-OPNA',
     'PICO-EXEM',
-    'POMPOM-MZVS',
     'QUACKINGSTICK',
     'SCARLET',
     'SPHERION',
@@ -123,6 +117,19 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'WILLOW-TFIY',
     'WORMDINGLER-JQAO',
 ]
+
+CHROMEOS_RECOVERY_ARM64_HWIDS = [
+    'KINGOFTOWN-KDDA',
+    'LAZOR',
+    'LIMOZEEN',
+    'PAZQUEL-HGNV',
+    'PAZQUEL-OPNA',
+    'POMPOM-MZVS',
+]
+
+MINIMUM_INPUTSTREAM_VERSION_ARM64 = {
+    'inputstream.adaptive': '20.3.5',
+}
 
 CHROMEOS_BLOCK_SIZE = 512
 

--- a/lib/inputstreamhelper/kodiutils.py
+++ b/lib/inputstreamhelper/kodiutils.py
@@ -80,9 +80,9 @@ def translate_path(path):
     return to_unicode(translatePath(from_unicode(path)))
 
 
-def get_addon_info(key):
+def get_addon_info(key, addon=ADDON):
     """Return addon information"""
-    return to_unicode(ADDON.getAddonInfo(key))
+    return to_unicode(addon.getAddonInfo(key))
 
 
 def addon_id():
@@ -95,9 +95,14 @@ def addon_profile():
     return translate_path(get_addon_info('profile'))
 
 
-def addon_version():
+def addon_version(addon_name=None):
     """Cache and return add-on version"""
-    return get_addon_info('version')
+    if not addon_name:
+        addon = ADDON
+    else:
+        addon = xbmcaddon.Addon(addon_name)
+
+    return get_addon_info('version', addon)
 
 
 def browsesingle(type, heading, shares='', mask='', useThumbs=False, treatAsFolder=False, defaultt=None):  # pylint: disable=invalid-name,redefined-builtin

--- a/lib/inputstreamhelper/utils.py
+++ b/lib/inputstreamhelper/utils.py
@@ -7,6 +7,8 @@ import os
 from time import time
 from socket import timeout
 from ssl import SSLError
+import struct
+
 
 try:  # Python 3
     from urllib.error import HTTPError, URLError
@@ -309,6 +311,11 @@ def arch():
 
     arch.cached = sys_arch
     return sys_arch
+
+
+def userspace64():
+    """To check if userspace is 64bit or 32bit"""
+    return struct.calcsize('P') * 8 == 64
 
 
 def hardlink(src, dest):

--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -8,7 +8,7 @@ import json
 
 from .. import config
 from ..kodiutils import browsesingle, localize, log, ok_dialog, open_file, progress_dialog, yesno_dialog
-from ..utils import diskspace, http_download, http_get, parse_version, sizeof_fmt, store, system_os, update_temp_path
+from ..utils import diskspace, http_download, http_get, parse_version, sizeof_fmt, store, system_os, update_temp_path, userspace64
 from .arm_chromeos import ChromeOSImage
 
 
@@ -16,8 +16,12 @@ def select_best_chromeos_image(devices):
     """Finds the newest and smallest of the ChromeOS images given"""
     log(0, 'Find best ARM image to use from the Chrome OS recovery.json')
 
-    arm_hwids = [h for arm_hwid in config.CHROMEOS_RECOVERY_ARM_HWIDS
-                   for h in ['^{} '.format(arm_hwid), '^{}-.*'.format(arm_hwid), '^{}.*'.format(arm_hwid)]]
+    if userspace64():
+        arm_hwids = config.CHROMEOS_RECOVERY_ARM64_HWIDS
+    else:
+        arm_hwids = config.CHROMEOS_RECOVERY_ARM_HWIDS
+
+    arm_hwids = [h for arm_hwid in arm_hwids for h in ['^{} '.format(arm_hwid), '^{}-.*'.format(arm_hwid), '^{}.*'.format(arm_hwid)]]
     best = None
     for device in devices:
         # Select ARM hardware only

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -153,10 +153,6 @@ msgctxt "#30038"
 msgid "Install Widevine"
 msgstr ""
 
-msgctxt "#30039"
-msgid "[B]Widevine CDM[/B] is currently not available natively on ARM64. Please switch to a 32-bit userspace for [B]Widevine CDM[/B] support."
-msgstr ""
-
 msgctxt "#30040"
 msgid "Update available"
 msgstr ""
@@ -263,6 +259,10 @@ msgstr ""
 
 msgctxt "#30067"
 msgid "Specify the resource Widevine should be extracted from."
+msgstr ""
+
+msgctxt "#30068"
+msgid "On ARM64 with 64bit userspace, a newer version of {addon} is needed to use [B]Widevine CDM[/B] natively. Please either switch to a 32-bit userspace or install {addon} in version {version} or later."
 msgstr ""
 
 

--- a/tests/checkchromeos.py
+++ b/tests/checkchromeos.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from xml.etree import ElementTree as ET
 import requests
-from lib.inputstreamhelper.config import CHROMEOS_RECOVERY_ARM_HWIDS
+from lib.inputstreamhelper.config import CHROMEOS_RECOVERY_ARM_HWIDS, CHROMEOS_RECOVERY_ARM64_HWIDS
 
 
 class OutdatedException(Exception):
@@ -108,11 +108,11 @@ def check_hwids():
         if hwid not in hwids:
             hwids.append(hwid)
 
-    for item in CHROMEOS_RECOVERY_ARM_HWIDS:
+    for item in CHROMEOS_RECOVERY_ARM_HWIDS + CHROMEOS_RECOVERY_ARM64_HWIDS:
         if item not in hwids:
             messages.append('{} is end-of-life, consider removing it from inputstreamhelper config'.format(item))
     for item in hwids:
-        if item not in CHROMEOS_RECOVERY_ARM_HWIDS:
+        if item not in CHROMEOS_RECOVERY_ARM_HWIDS + CHROMEOS_RECOVERY_ARM64_HWIDS:
             messages.append('{} is missing, please add it to inputstreamhelper config'.format(item))
     if messages:
         raise OutdatedException(messages)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 [flake8]
 builtins = func
 max-line-length = 160
-ignore = E127,E129,FI13,FI50,FI51,FI53,FI54,W503
+ignore = E129,FI13,FI50,FI51,FI53,FI54,W503
 require-code = True
 min-version = 2.7
 exclude = .tox,experiment


### PR DESCRIPTION
Closes #530 

So far only LAZOR (and some others which use the same image) has the 64bit library. We need to monitor the other images for when/if they make the switch.
The path for `find_file()` could be changed accordingly, since the lib is not in `arm_cros`, but `arm_cros64` in those images.