### PR TITLE
Fix for select_best_chromeos_image.

### DIFF
--- a/lib/inputstreamhelper/widevine/arm.py
+++ b/lib/inputstreamhelper/widevine/arm.py
@@ -16,11 +16,13 @@ def select_best_chromeos_image(devices):
     """Finds the newest and smallest of the ChromeOS images given"""
     log(0, 'Find best ARM image to use from the Chrome OS recovery.json')
 
+    arm_hwids = [h for arm_hwid in config.CHROMEOS_RECOVERY_ARM_HWIDS
+                   for h in ['^{} '.format(arm_hwid), '^{}-.*'.format(arm_hwid), '^{}.*'.format(arm_hwid)]]
     best = None
     for device in devices:
         # Select ARM hardware only
-        for arm_hwid in config.CHROMEOS_RECOVERY_ARM_HWIDS:
-            if '^{0} '.format(arm_hwid) in device['hwidmatch']:
+        for arm_hwid in arm_hwids:
+            if arm_hwid in device['hwidmatch']:
                 hwid = arm_hwid
                 break  # We found an ARM device, rejoice !
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 [flake8]
 builtins = func
 max-line-length = 160
-ignore = E129,FI13,FI50,FI51,FI53,FI54,W503
+ignore = E127,E129,FI13,FI50,FI51,FI53,FI54,W503
 require-code = True
 min-version = 2.7
 exclude = .tox,experiment


### PR DESCRIPTION
Until now, select_best_chromeos_image actually only used less than half of the hwids in the list, since many don't have that space after the name.

In the long run, I think it is better to use the board names, since there are multiple hwids/code names which use the same image. The name of the image always contains the board name. That will also make life easier if they switch from the 32bit to 64bit lib, cause we only have to change one board name, instead of checking for all code names.