### PR TITLE
prepare for v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.7.0 (2024-09-24)
+- Get rid of distutils dependency (@horstle, @emilsvennesson)
+- Option to get Widevine from lacros image (@horstle)
+- Remove support for Python 2 and pre-Matrix Kodi versions (@horstle)
+
 ### v0.6.1 (2023-05-30)
 - Performance improvements on Linux ARM (@horstle)
 - This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.6.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.7.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -25,6 +25,11 @@
     <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
+v0.7.0 (2024-09-24)
+- Get rid of distutils dependency
+- Option to get Widevine from lacros image
+- Remove support for Python 2 and pre-Matrix Kodi versions
+
 v0.6.1 (2023-05-30)
 - Performance improvements on Linux ARM
 - This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.


### PR DESCRIPTION
I decided on 0.7.0 for this version because we are removing support for Python 2.

@horstle, do you think we should include anything else in this version? I'd appreciate your eyes on this seeing as you've done the heavy lifting as usual. :-)