### PR TITLE
Fix remove tree can fail on directory not found

### DIFF
--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -194,7 +194,11 @@ def remove_old_backups(bpath):
     while len(versions) > max_backups + 1:
         remove_version = str(versions[1] if versions[0] == parse_version(installed_version) else versions[0])
         log(0, 'Removing oldest backup which is not installed: {version}', version=remove_version)
-        remove_tree(os.path.join(bpath, remove_version))
+        try:
+            remove_tree(os.path.join(bpath, remove_version))
+        except FileNotFoundError as e:
+            log(0, 'Failed to remove directory for version {version}', version=remove_version)
+
         versions = sorted([parse_version(version) for version in listdir(bpath)])
 
     return


### PR DESCRIPTION
When having one of old versions not available the removal feels which bricks the whole plugin.

This PR adds a catch for file not found errors on removal, as this usually means that the version is already removed.
Further, due to the refetching of available versions afterwards this would give the option to retry even if it failed.