### PR TITLE
Skip ldd check on ARM Linux

### DIFF
--- a/lib/inputstreamhelper/widevine/widevine.py
+++ b/lib/inputstreamhelper/widevine/widevine.py
@@ -126,6 +126,9 @@ def missing_widevine_libs():
     if system_os() != 'Linux':  # this should only be needed for linux
         return None
 
+    if arch() in {'arm', 'arm64'}: # ldd will fail with missing GLIBC_ABI_DT_RELR error and is useless
+        return None
+
     if cmd_exists('ldd'):
         widevinecdm = widevinecdm_path()
         if not os.access(widevinecdm, os.X_OK):


### PR DESCRIPTION
While the commonly used glibc hack-patch enables kodi on ARM Linux to use the ChromeOS widevine library ldd will still correctly fail with an error message because of the missing GLIBC_ABI_DT_RELR dependency.

This makes the test quite useless on ARM, results in repeated logspam and the logged error may also be misleading to users.